### PR TITLE
Sorting search results

### DIFF
--- a/gramps_webapi/api/resources/search.py
+++ b/gramps_webapi/api/resources/search.py
@@ -91,6 +91,7 @@ class SearchResource(GrampsJSONEncoder, ProtectedResource):
             "query": fields.Str(required=True, validate=validate.Length(min=1)),
             "page": fields.Int(missing=1, validate=validate.Range(min=1)),
             "pagesize": fields.Int(missing=20, validate=validate.Range(min=1)),
+            "sort": fields.DelimitedList(fields.Str(validate=validate.Length(min=1))),
             "profile": fields.DelimitedList(
                 fields.Str(validate=validate.Length(min=1)),
                 validate=validate.ContainsOnly(
@@ -110,6 +111,7 @@ class SearchResource(GrampsJSONEncoder, ProtectedResource):
             pagesize=args["pagesize"],
             # search in private records if allowed to
             include_private=has_permissions([PERM_VIEW_PRIVATE]),
+            sort=args.get("sort"),
         )
         if hits:
             locale = get_locale_for_language(args["locale"], default=True)

--- a/gramps_webapi/api/resources/util.py
+++ b/gramps_webapi/api/resources/util.py
@@ -356,7 +356,7 @@ def get_person_profile_for_object(
                 base_event=birth_event,
                 label="age",
                 locale=locale,
-                role=str(event_ref.get_role()),
+                role=locale.translation.sgettext(event_ref.get_role().xml_str()),
             )
             for event_ref in person.event_ref_list
         ]
@@ -418,7 +418,7 @@ def get_family_profile_for_object(
         "mother": get_person_profile_for_handle(
             db_handle, family.mother_handle, options, locale=locale
         ),
-        "relationship": locale.translation.sgettext(str(family.type)),
+        "relationship": locale.translation.sgettext(family.type.xml_str()),
         "marriage": marriage,
         "divorce": divorce,
         "children": [

--- a/gramps_webapi/api/search.py
+++ b/gramps_webapi/api/search.py
@@ -23,7 +23,7 @@
 from collections import OrderedDict
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, Generator, Tuple
+from typing import Any, Dict, Generator, List, Optional, Tuple
 
 from gramps.gen.db.base import DbReadBase
 from gramps.gen.lib import Name
@@ -33,6 +33,7 @@ from whoosh.qparser import FieldsPlugin, MultifieldParser, QueryParser
 from whoosh.qparser.dateparse import DateParserPlugin
 from whoosh.query import Term
 from whoosh.searching import Hit
+from whoosh.sorting import FieldFacet
 
 from ..const import PRIMARY_GRAMPS_OBJECTS
 from ..types import FilenameOrPath
@@ -96,21 +97,21 @@ class SearchIndexer:
 
     # schema for searches of all (public + private) info
     SCHEMA = Schema(
-        type=ID(stored=True),
+        type=ID(stored=True, sortable=True),
         handle=ID(stored=True, unique=True),
         private=BOOLEAN(stored=True),
         text=TEXT(),
         text_private=TEXT(),
-        changed=DATETIME(),
+        changed=DATETIME(sortable=True),
     )
 
     # schema for searches of public info only
     SCHEMA_PUBLIC = Schema(
-        type=ID(stored=True),
+        type=ID(stored=True, sortable=True),
         handle=ID(stored=True, unique=True),
         private=BOOLEAN(stored=True),
         text=TEXT(),
-        changed=DATETIME(),
+        changed=DATETIME(sortable=True),
     )
 
     def __init__(self, index_dir=FilenameOrPath):
@@ -153,6 +154,22 @@ class SearchIndexer:
             "score": hit.score,
         }
 
+    def _get_sorting(
+        self, sort: Optional[List[str]] = None,
+    ) -> Optional[List[FieldFacet]]:
+        """Get the appropriate field facets for sorting."""
+        if not sort:
+            return None
+        facets = []
+        allowed_sorters = {"type", "changed"}
+        for sorter in sort:
+            _field = sorter.lstrip("+-")
+            if _field not in allowed_sorters:
+                continue
+            reverse = sorter.startswith("-")
+            facets.append(FieldFacet(_field, reverse=reverse))
+        return facets
+
     def search(
         self,
         query: str,
@@ -160,6 +177,7 @@ class SearchIndexer:
         pagesize: int,
         include_private: bool = True,
         extend: bool = False,
+        sort: Optional[List[str]] = None,
     ):
         """Search the index.
 
@@ -174,5 +192,8 @@ class SearchIndexer:
         mask = None if include_private else Term("private", True)
         parsed_query = query_parser.parse(query)
         with self.index().searcher() as searcher:
-            results = searcher.search_page(parsed_query, page, pagesize, mask=mask)
+            sortedby = self._get_sorting(sort)
+            results = searcher.search_page(
+                parsed_query, page, pagesize, mask=mask, sortedby=sortedby
+            )
             return results.total, [self.format_hit(hit) for hit in results]

--- a/gramps_webapi/api/search.py
+++ b/gramps_webapi/api/search.py
@@ -25,6 +25,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, Generator, List, Optional, Tuple
 
+from flask import current_app
 from gramps.gen.db.base import DbReadBase
 from gramps.gen.lib import Name
 from whoosh import index
@@ -136,13 +137,16 @@ class SearchIndexer:
         """Reindex the whole database."""
         with self.index(overwrite=True).writer() as writer:
             for obj_dict in iter_obj_strings(db_handle):
-                writer.add_document(
-                    type=obj_dict["class_name"].lower(),
-                    handle=obj_dict["handle"],
-                    text=obj_dict["string"],
-                    text_private=obj_dict["string_private"],
-                    changed=obj_dict["changed"],
-                )
+                try:
+                    writer.add_document(
+                        type=obj_dict["class_name"].lower(),
+                        handle=obj_dict["handle"],
+                        text=obj_dict["string"],
+                        text_private=obj_dict["string_private"],
+                        changed=obj_dict["changed"],
+                    )
+                except:
+                    current_app.logger.error("Failed adding object {}".format(handle))
 
     @staticmethod
     def format_hit(hit: Hit) -> Dict[str, Any]:

--- a/gramps_webapi/api/search.py
+++ b/gramps_webapi/api/search.py
@@ -89,7 +89,7 @@ def iter_obj_strings(db_handle: DbReadBase,) -> Generator[Dict[str, Any], None, 
                     "private": private,
                     "string": obj_string,
                     "string_private": obj_string_private,
-                    "changed": datetime.fromtimestamp(obj.change),
+                    "change": datetime.fromtimestamp(obj.change),
                 }
 
 
@@ -103,7 +103,7 @@ class SearchIndexer:
         private=BOOLEAN(stored=True),
         text=TEXT(),
         text_private=TEXT(),
-        changed=DATETIME(sortable=True),
+        change=DATETIME(sortable=True),
     )
 
     # schema for searches of public info only
@@ -112,7 +112,7 @@ class SearchIndexer:
         handle=ID(stored=True, unique=True),
         private=BOOLEAN(stored=True),
         text=TEXT(),
-        changed=DATETIME(sortable=True),
+        change=DATETIME(sortable=True),
     )
 
     def __init__(self, index_dir=FilenameOrPath):
@@ -143,7 +143,7 @@ class SearchIndexer:
                         handle=obj_dict["handle"],
                         text=obj_dict["string"],
                         text_private=obj_dict["string_private"],
-                        changed=obj_dict["changed"],
+                        change=obj_dict["change"],
                     )
                 except:
                     current_app.logger.error(
@@ -167,7 +167,7 @@ class SearchIndexer:
         if not sort:
             return None
         facets = []
-        allowed_sorters = {"type", "changed"}
+        allowed_sorters = {"type", "change"}
         for sorter in sort:
             _field = sorter.lstrip("+-")
             if _field not in allowed_sorters:

--- a/gramps_webapi/api/search.py
+++ b/gramps_webapi/api/search.py
@@ -146,7 +146,9 @@ class SearchIndexer:
                         changed=obj_dict["changed"],
                     )
                 except:
-                    current_app.logger.error("Failed adding object {}".format(handle))
+                    current_app.logger.error(
+                        "Failed adding object {}".format(obj_dict["handle"])
+                    )
 
     @staticmethod
     def format_hit(hit: Hit) -> Dict[str, Any]:

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -4281,6 +4281,17 @@ paths:
         type: integer
         default: 20
         description: "The number of search results that constitute a page."
+      - name: sort
+        in: query
+        required: false
+        type: string
+        description: >
+          A comma delimited list of keys to sort the result set by.  By default the sort is in ascending order, if the key name starts with a - sign then the sort will be in descending order. For search the available keys are:
+
+            Key | Description
+            --- | -----------
+            change | The time the record was last updated
+            type | The type of object (e.g. person)
       - name: strip
         in: query
         required: false

--- a/tests/test_endpoints/test_search.py
+++ b/tests/test_endpoints/test_search.py
@@ -223,7 +223,7 @@ class TestSearch(unittest.TestCase):
         header = fetch_header(self.client, role=ROLE_OWNER)
         rv = self.client.get(
             TEST_URL
-            + "?query={}".format(quote("type:repository changed:'2012 to now'")),
+            + "?query={}".format(quote("type:repository change:'2012 to now'")),
             headers=header,
         )
         self.assertEqual(len(rv.json), 1)
@@ -234,7 +234,7 @@ class TestSearch(unittest.TestCase):
         header = fetch_header(self.client, role=ROLE_GUEST)
         rv = self.client.get(
             TEST_URL
-            + "?query={}".format(quote("type:repository changed:'2012 to now'")),
+            + "?query={}".format(quote("type:repository change:'2012 to now'")),
             headers=header,
         )
         self.assertEqual(len(rv.json), 1)
@@ -245,8 +245,8 @@ class TestSearch(unittest.TestCase):
         header = fetch_header(self.client, role=ROLE_OWNER)
         rv = self.client.get(
             TEST_URL
-            + "?sort=changed&pagesize=1&page=1&query={}".format(
-                quote("type:person changed:'1990 to now'")
+            + "?sort=change&pagesize=1&page=1&query={}".format(
+                quote("type:person change:'1990 to now'")
             ),
             headers=header,
         )
@@ -258,8 +258,8 @@ class TestSearch(unittest.TestCase):
         header = fetch_header(self.client, role=ROLE_OWNER)
         rv = self.client.get(
             TEST_URL
-            + "?sort=-changed&pagesize=1&page=1&query={}".format(
-                quote("type:person changed:'1990 to now'")
+            + "?sort=-change&pagesize=1&page=1&query={}".format(
+                quote("type:person change:'1990 to now'")
             ),
             headers=header,
         )

--- a/tests/test_endpoints/test_search.py
+++ b/tests/test_endpoints/test_search.py
@@ -253,19 +253,6 @@ class TestSearch(unittest.TestCase):
         self.assertEqual(len(rv.json), 1)
         self.assertEqual(rv.json[0]["object"]["gramps_id"], "I0552")
 
-    def test_get_search_oldest(self):
-        """Search for the oldest person record."""
-        header = fetch_header(self.client, role=ROLE_OWNER)
-        rv = self.client.get(
-            TEST_URL
-            + "?sort=changed&pagesize=1&page=1&query={}".format(
-                quote("type:person changed:'1990 to now'")
-            ),
-            headers=header,
-        )
-        self.assertEqual(len(rv.json), 1)
-        self.assertEqual(rv.json[0]["object"]["gramps_id"], "I0552")
-
     def test_get_search_newest(self):
         """Search for the newest person record."""
         header = fetch_header(self.client, role=ROLE_OWNER)

--- a/tests/test_endpoints/test_search.py
+++ b/tests/test_endpoints/test_search.py
@@ -239,3 +239,42 @@ class TestSearch(unittest.TestCase):
         )
         self.assertEqual(len(rv.json), 1)
         self.assertEqual(rv.json[0]["object"]["gramps_id"], "R0002")
+
+    def test_get_search_oldest(self):
+        """Search for the oldest person record."""
+        header = fetch_header(self.client, role=ROLE_OWNER)
+        rv = self.client.get(
+            TEST_URL
+            + "?sort=changed&pagesize=1&page=1&query={}".format(
+                quote("type:person changed:'1990 to now'")
+            ),
+            headers=header,
+        )
+        self.assertEqual(len(rv.json), 1)
+        self.assertEqual(rv.json[0]["object"]["gramps_id"], "I0552")
+
+    def test_get_search_oldest(self):
+        """Search for the oldest person record."""
+        header = fetch_header(self.client, role=ROLE_OWNER)
+        rv = self.client.get(
+            TEST_URL
+            + "?sort=changed&pagesize=1&page=1&query={}".format(
+                quote("type:person changed:'1990 to now'")
+            ),
+            headers=header,
+        )
+        self.assertEqual(len(rv.json), 1)
+        self.assertEqual(rv.json[0]["object"]["gramps_id"], "I0552")
+
+    def test_get_search_newest(self):
+        """Search for the newest person record."""
+        header = fetch_header(self.client, role=ROLE_OWNER)
+        rv = self.client.get(
+            TEST_URL
+            + "?sort=-changed&pagesize=1&page=1&query={}".format(
+                quote("type:person changed:'1990 to now'")
+            ),
+            headers=header,
+        )
+        self.assertEqual(len(rv.json), 1)
+        self.assertEqual(rv.json[0]["object"]["gramps_id"], "I0363")


### PR DESCRIPTION
This adds a new `sort` parameter that allows to sort search results by a field (any not by score). The only meaningful possibility at the moment is `changed` to sort by the last changed date. I used the same convention as for the other endpoints: `-changed` is descending.

I also fixed the unit tests (I hope) as part of this PR.

Will add API docs in a moment.