### PR TITLE
Add ratings parameter

### DIFF
--- a/gramps_webapi/api/resources/base.py
+++ b/gramps_webapi/api/resources/base.py
@@ -163,6 +163,7 @@ class GrampsObjectResource(GrampsObjectResourceHelper, Resource):
                         "events",
                         "age",
                         "span",
+                        "ratings",
                         "references",
                     ]
                 ),
@@ -245,6 +246,7 @@ class GrampsObjectsResource(GrampsObjectResourceHelper, Resource):
                         "events",
                         "age",
                         "span",
+                        "ratings",
                         "references",
                     ]
                 ),

--- a/gramps_webapi/api/resources/events.py
+++ b/gramps_webapi/api/resources/events.py
@@ -32,8 +32,7 @@ from gramps.gen.utils.grampslocale import GrampsLocale
 from webargs import fields, validate
 
 from ...types import Handle
-from ..util import use_args
-from ..util import get_db_handle, get_locale_for_language
+from ..util import get_db_handle, get_locale_for_language, use_args
 from . import ProtectedResource
 from .base import (
     GrampsObjectProtectedResource,
@@ -58,16 +57,16 @@ class EventResourceHelper(GrampsObjectResourceHelper):
     ) -> Event:
         """Extend event attributes as needed."""
         db_handle = self.db_handle
+        if "extend" in args:
+            obj.extended = get_extended_attributes(db_handle, obj, args)
+            if "all" in args["extend"] or "place" in args["extend"]:
+                obj.extended["place"] = get_place_by_handle(db_handle, obj.place)
         if "profile" in args:
             if "families" in args["profile"] or "events" in args["profile"]:
                 abort(422)
             obj.profile = get_event_profile_for_object(
                 db_handle, obj, args["profile"], locale=locale
             )
-        if "extend" in args:
-            obj.extended = get_extended_attributes(db_handle, obj, args)
-            if "all" in args["extend"] or "place" in args["extend"]:
-                obj.extended["place"] = get_place_by_handle(db_handle, obj.place)
         return obj
 
 

--- a/gramps_webapi/api/resources/util.py
+++ b/gramps_webapi/api/resources/util.py
@@ -110,7 +110,9 @@ def get_sex_profile(person: Person) -> str:
 
 
 def get_event_participants_for_handle(
-    db_handle: DbReadBase, handle: Handle, locale: GrampsLocale = glocale,
+    db_handle: DbReadBase,
+    handle: Handle,
+    locale: GrampsLocale = glocale,
 ) -> Dict:
     """Get event participants given a handle."""
     result = {"people": [], "families": []}
@@ -177,6 +179,10 @@ def get_event_profile_for_object(
         result["participants"] = get_event_participants_for_handle(
             db_handle, event.handle, locale=locale
         )
+    if "all" in args or "ratings" in args:
+        count, confidence = get_rating(db_handle, event)
+        result["citations"] = count
+        result["confidence"] = confidence
     if base_event is not None:
         result[label] = (
             Span(base_event.date, event.date)
@@ -212,43 +218,71 @@ def get_event_profile_for_handle(
 
 
 def get_birth_profile(
-    db_handle: DbReadBase, person: Person, locale: GrampsLocale = glocale
+    db_handle: DbReadBase,
+    person: Person,
+    args: Union[List, None] = None,
+    locale: GrampsLocale = glocale,
 ) -> Tuple[Dict, Union[Event, None]]:
     """Return best available birth information for a person."""
     event = get_birth_or_fallback(db_handle, person)
     if event is None:
         return {}, None
-    return get_event_profile_for_object(db_handle, event, args=[], locale=locale), event
+    args = args or []
+    return (
+        get_event_profile_for_object(db_handle, event, args=args, locale=locale),
+        event,
+    )
 
 
 def get_death_profile(
-    db_handle: DbReadBase, person: Person, locale: GrampsLocale = glocale
+    db_handle: DbReadBase,
+    person: Person,
+    args: Union[List, None] = None,
+    locale: GrampsLocale = glocale,
 ) -> Tuple[Dict, Union[Event, None]]:
     """Return best available death information for a person."""
     event = get_death_or_fallback(db_handle, person)
     if event is None:
         return {}, None
-    return get_event_profile_for_object(db_handle, event, args=[], locale=locale), event
+    args = args or []
+    return (
+        get_event_profile_for_object(db_handle, event, args=args, locale=locale),
+        event,
+    )
 
 
 def get_marriage_profile(
-    db_handle: DbReadBase, family: Family, locale: GrampsLocale = glocale
+    db_handle: DbReadBase,
+    family: Family,
+    args: Union[List, None] = None,
+    locale: GrampsLocale = glocale,
 ) -> Tuple[Dict, Union[Event, None]]:
     """Return best available marriage information for a couple."""
     event = get_marriage_or_fallback(db_handle, family)
     if event is None:
         return {}, None
-    return get_event_profile_for_object(db_handle, event, args=[], locale=locale), event
+    args = args or []
+    return (
+        get_event_profile_for_object(db_handle, event, args=args, locale=locale),
+        event,
+    )
 
 
 def get_divorce_profile(
-    db_handle: DbReadBase, family: Family, locale: GrampsLocale = glocale
+    db_handle: DbReadBase,
+    family: Family,
+    args: Union[List, None] = None,
+    locale: GrampsLocale = glocale,
 ) -> Tuple[Dict, Union[Event, None]]:
     """Return best available divorce information for a couple."""
     event = get_divorce_or_fallback(db_handle, family)
     if event is None:
         return {}, None
-    return get_event_profile_for_object(db_handle, event, args=[], locale=locale), event
+    args = args or {}
+    return (
+        get_event_profile_for_object(db_handle, event, args=args, locale=locale),
+        event,
+    )
 
 
 def _format_place_type(
@@ -320,9 +354,15 @@ def get_person_profile_for_object(
 ) -> Person:
     """Get person profile given a Person."""
     options = []
+    if "all" in args or "ratings" in args:
+        options.append("ratings")
     name_display = NameDisplay(xlocale=locale)
-    birth, birth_event = get_birth_profile(db_handle, person, locale=locale)
-    death, death_event = get_death_profile(db_handle, person, locale=locale)
+    birth, birth_event = get_birth_profile(
+        db_handle, person, args=options, locale=locale
+    )
+    death, death_event = get_death_profile(
+        db_handle, person, args=options, locale=locale
+    )
     if "all" in args or "age" in args:
         options.append("age")
         if birth_event is not None:
@@ -396,8 +436,14 @@ def get_family_profile_for_object(
 ) -> Family:
     """Get family profile given a Family."""
     options = []
-    marriage, marriage_event = get_marriage_profile(db_handle, family, locale=locale)
-    divorce, divorce_event = get_divorce_profile(db_handle, family, locale=locale)
+    if "all" in args or "ratings" in args:
+        options.append("ratings")
+    marriage, marriage_event = get_marriage_profile(
+        db_handle, family, args=options, locale=locale
+    )
+    divorce, divorce_event = get_divorce_profile(
+        db_handle, family, args=options, locale=locale
+    )
     if "all" in args or "span" in args:
         if marriage_event is not None:
             marriage["span"] = locale.translation.sgettext("0 days")
@@ -610,9 +656,11 @@ def get_soundex(
 
 
 def get_reference_profile_for_object(
-    db_handle: DbReadBase, obj: GrampsObject, locale: GrampsLocale = glocale,
+    db_handle: DbReadBase,
+    obj: GrampsObject,
+    locale: GrampsLocale = glocale,
 ) -> Dict:
-    """ bla"""
+    """Return reference profiles for an object."""
     profile = {}
     # get backlink handles
     if hasattr(obj, "backlinks"):
@@ -651,3 +699,21 @@ def get_reference_profile_for_object(
             for handle in backlink_handles["place"]
         ]
     return profile
+
+
+def get_rating(db_handle: DbReadBase, obj: GrampsObject) -> Tuple[int, int]:
+    """Return rating based on citations."""
+    count = 0
+    confidence = 0
+    if hasattr(obj, "citation_list"):
+        count = len(obj.citation_list)
+        if hasattr(obj, "extended") and "citations" in obj["extended"]:
+            for citation in obj["extended"]["citations"]:
+                if citation.confidence > confidence:
+                    confidence = citation.confidence
+        else:
+            for handle in obj.citation_list:
+                citation = db_handle.get_citation_from_handle(handle)
+                if citation.confidence > confidence:
+                    confidence = citation.confidence
+    return count, confidence

--- a/gramps_webapi/api/resources/util.py
+++ b/gramps_webapi/api/resources/util.py
@@ -707,8 +707,8 @@ def get_rating(db_handle: DbReadBase, obj: GrampsObject) -> Tuple[int, int]:
     confidence = 0
     if hasattr(obj, "citation_list"):
         count = len(obj.citation_list)
-        if hasattr(obj, "extended") and "citations" in obj["extended"]:
-            for citation in obj["extended"]["citations"]:
+        if hasattr(obj, "extended") and "citations" in obj.extended:
+            for citation in obj.extended["citations"]:
                 if citation.confidence > confidence:
                     confidence = citation.confidence
         else:

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -536,6 +536,7 @@ paths:
             self | Returns name, sex, birth and death information and is an implied default when events or families specified
             span | Returns elapsed time span from union that formed the family and familial events
             events | Returns event list with name, date and location
+            ratings | Returns citation count and highest confidence rating for events
             families | Returns family information with parents, children, and key relationship between parents
             references | Returns information about objects that refer to the person
       responses:
@@ -641,6 +642,7 @@ paths:
             self | Returns name, sex, birth and death information and is an implied default when events or families specified
             span | Returns elapsed time span from union that formed the family and familial events
             events | Returns event list with name, date and location
+            ratings | Returns citation count and highest confidence rating for events    
             families | Returns family information with parents, children, and key relationship between parents
             references | Returns information about objects that refer to the person
       responses:
@@ -787,6 +789,12 @@ paths:
             residence | Residence, Census, Property
             other | Cause of Death, Medical Information, Title of Nobility, Number of Marriages
             custom | All user defined custom events
+      - name: ratings
+        in: query
+        required: false
+        type: boolean
+        default: false
+        description: "Indicates whether or not to include total citation count and highest confidence score."
       - name: precision
         in: query
         required: false
@@ -1009,6 +1017,7 @@ paths:
             self | Returns family information with parents, children, and key relationship between parents and is an implied default if events specified
             span | Returns elapsed time span from union that formed the family and familial events
             events | Returns family event list with name, date and location
+            ratings | Returns citation count and highest confidence rating for events
             references | Returns information about objects that refer to the family
       responses:
         200:
@@ -1112,6 +1121,7 @@ paths:
             self | Returns family information with parents, children, and key relationship between parents and is an implied default if events specified
             span | Returns elapsed time span from union that formed the family and familial events
             events | Returns family event list with name, date and location
+            ratings | Returns citation count and highest confidence rating for events
             references | Returns information about objects that refer to the family
       responses:
         200:
@@ -1185,6 +1195,12 @@ paths:
             residence | Residence, Census, Property
             other | Cause of Death, Medical Information, Title of Nobility, Number of Marriages
             custom | All user defined custom events
+      - name: ratings
+        in: query
+        required: false
+        type: boolean
+        default: false
+        description: "Indicates whether or not to include total citation count and highest confidence score."
       - name: locale
         in: query
         required: false
@@ -1391,6 +1407,7 @@ paths:
             ------ | --------
             all | Returns all information below
             events | Returns event name, date and location
+            ratings | Returns citation count and highest confidence rating for events
             participants | Returns information about the event participants
             references | Returns information about objects that refer to the family
       responses:
@@ -1483,6 +1500,7 @@ paths:
             ------ | --------
             all | Returns all information below
             events | Returns event name, date and location
+            ratings | Returns citation count and highest confidence rating for events
             references | Returns information about objects that refer to the event
       responses:
         200:
@@ -4156,6 +4174,12 @@ paths:
             residence | Residence, Census, Property
             other | Cause of Death, Medical Information, Title of Nobility, Number of Marriages
             custom | All user defined custom events
+      - name: ratings
+        in: query
+        required: false
+        type: boolean
+        default: false
+        description: "Indicates whether or not to include total citation count and highest confidence score."
       - name: precision
         in: query
         required: false
@@ -4320,6 +4344,12 @@ paths:
             residence | Residence, Census, Property
             other | Cause of Death, Medical Information, Title of Nobility, Number of Marriages
             custom | All user defined custom events
+      - name: ratings
+        in: query
+        required: false
+        type: boolean
+        default: false
+        description: "Indicates whether or not to include total citation count and highest confidence score."
       - name: locale
         in: query
         required: false
@@ -5837,6 +5867,14 @@ definitions:
   EventProfile:
     type: object
     properties:
+      citations:
+        description: "Total citations supporting the event."
+        type: integer
+        example: 2
+      confidence:
+        description: "Highest confidence rating among the supporting citations."
+        type: integer
+        example: 3
       date:
         description: "Date of the event."
         type: string
@@ -7963,6 +8001,14 @@ definitions:
         description: "The age of the person the timeline is for at the time of the event."
         type: string
         example: "2 years"
+      citations:
+        description: "Total citations supporting the event."
+        type: integer
+        example: 2
+      confidence:
+        description: "Highest confidence rating among the supporting citations."
+        type: integer
+        example: 3
       date:
         description: "Date of the event."
         type: string

--- a/tests/test_endpoints/test_events.py
+++ b/tests/test_endpoints/test_events.py
@@ -379,10 +379,14 @@ class TestEvents(unittest.TestCase):
 
     def test_get_events_parameter_profile_expected_result(self):
         """Test expected response."""
-        rv = check_success(self, TEST_URL + "?page=1&keys=profile&profile=all")
+        rv = check_success(
+            self, TEST_URL + "?page=1&pagesize=1&keys=profile&profile=all"
+        )
         self.assertEqual(
             rv[0]["profile"],
             {
+                "citations": 0,
+                "confidence": 0,
                 "date": "1987-08-29",
                 "place": "Gainesville, Llano, TX, USA",
                 "type": "Birth",
@@ -618,10 +622,14 @@ class TestEventsHandle(unittest.TestCase):
 
     def test_get_events_handle_parameter_profile_expected_result(self):
         """Test response as expected."""
-        rv = check_success(self, TEST_URL + "a5af0eb6dd140de132c?profile=all")
+        rv = check_success(
+            self, TEST_URL + "a5af0eb6dd140de132c?keys=profile&profile=all"
+        )
         self.assertEqual(
             rv["profile"],
             {
+                "citations": 0,
+                "confidence": 0,
                 "date": "1250",
                 "place": "Atchison, Atchison, KS, USA",
                 "type": "Birth",
@@ -672,6 +680,8 @@ class TestEventsHandle(unittest.TestCase):
         self.assertEqual(
             rv["profile"],
             {
+                "citations": 0,
+                "confidence": 0,
                 "date": "1250",
                 "place": "Atchison, Atchison, KS, USA",
                 "type": "Geburt",

--- a/tests/test_endpoints/test_families.py
+++ b/tests/test_endpoints/test_families.py
@@ -418,7 +418,9 @@ class TestFamilies(unittest.TestCase):
 
     def test_get_families_parameter_profile_expected_result(self):
         """Test expected response."""
-        rv = check_success(self, TEST_URL + "?page=1&keys=profile&profile=all")
+        rv = check_success(
+            self, TEST_URL + "?page=1&pagesize=1&keys=profile&profile=all"
+        )
         self.assertEqual(
             rv[0]["profile"],
             {
@@ -426,13 +428,15 @@ class TestFamilies(unittest.TestCase):
                     {
                         "birth": {
                             "age": "0 days",
+                            "citations": 0,
+                            "confidence": 0,
                             "date": "203 (Islamic)",
                             "place": "",
                             "type": "Birth",
                         },
                         "death": {},
-                        "handle": "cc82060516c6c141500",
                         "gramps_id": "I2115",
+                        "handle": "cc82060516c6c141500",
                         "name_given": "صالح",
                         "name_surname": "",
                         "sex": "M",
@@ -444,35 +448,44 @@ class TestFamilies(unittest.TestCase):
                 "father": {
                     "birth": {
                         "age": "0 days",
+                        "citations": 0,
+                        "confidence": 0,
                         "date": "164-03-00 (Islamic)",
                         "place": "",
                         "type": "Birth",
                     },
                     "death": {
                         "age": "77 years, 11 days",
+                        "citations": 0,
+                        "confidence": 0,
                         "date": "241-03-12 (Islamic)",
                         "place": "",
                         "type": "Death",
                     },
-                    "handle": "cc82060504445ab6deb",
                     "gramps_id": "I2111",
+                    "handle": "cc82060504445ab6deb",
                     "name_given": "أحمد",
                     "name_surname": "",
                     "sex": "M",
                 },
-                "handle": "cc82060505948b9e57f",
                 "gramps_id": "F0745",
+                "handle": "cc82060505948b9e57f",
                 "marriage": {},
                 "mother": {
                     "birth": {},
-                    "death": {"date": "234 (Islamic)", "place": "", "type": "Death"},
-                    "handle": "cc8206050980ea622d0",
+                    "death": {
+                        "citations": 0,
+                        "confidence": 0,
+                        "date": "234 (Islamic)",
+                        "place": "",
+                        "type": "Death",
+                    },
                     "gramps_id": "I2112",
+                    "handle": "cc8206050980ea622d0",
                     "name_given": "العباسة",
                     "name_surname": "الفضل",
                     "sex": "F",
                 },
-                "relationship": "Married",
                 "references": {
                     "person": [
                         {
@@ -520,6 +533,7 @@ class TestFamilies(unittest.TestCase):
                         },
                     ]
                 },
+                "relationship": "Married",
             },
         )
 
@@ -747,7 +761,9 @@ class TestFamiliesHandle(unittest.TestCase):
 
     def test_get_families_handle_parameter_profile_expected_result(self):
         """Test response as expected."""
-        rv = check_success(self, TEST_URL + "7MTJQCHRUUYSUA8ABB?profile=all")
+        rv = check_success(
+            self, TEST_URL + "7MTJQCHRUUYSUA8ABB?keys=profile&profile=all"
+        )
         self.assertEqual(
             rv["profile"],
             {
@@ -755,13 +771,15 @@ class TestFamiliesHandle(unittest.TestCase):
                     {
                         "birth": {
                             "age": "0 days",
+                            "citations": 0,
+                            "confidence": 0,
                             "date": "1983-10-05",
                             "place": "Ottawa, La Salle, IL, USA",
                             "type": "Birth",
                         },
                         "death": {},
-                        "handle": "1GWJQCGOOZ8FJW3YK9",
                         "gramps_id": "I0124",
+                        "handle": "1GWJQCGOOZ8FJW3YK9",
                         "name_given": "Stephen Gerard",
                         "name_surname": "Garner",
                         "sex": "M",
@@ -769,13 +787,15 @@ class TestFamiliesHandle(unittest.TestCase):
                     {
                         "birth": {
                             "age": "0 days",
+                            "citations": 0,
+                            "confidence": 0,
                             "date": "1985-02-11",
                             "place": "Ottawa, La Salle, IL, USA",
                             "type": "Birth",
                         },
                         "death": {},
-                        "handle": "IGWJQCSVT8NXTFXOFJ",
                         "gramps_id": "I0125",
+                        "handle": "IGWJQCSVT8NXTFXOFJ",
                         "name_given": "Daniel Patrick",
                         "name_surname": "Garner",
                         "sex": "M",
@@ -784,6 +804,8 @@ class TestFamiliesHandle(unittest.TestCase):
                 "divorce": {},
                 "events": [
                     {
+                        "citations": 0,
+                        "confidence": 0,
                         "date": "1979-01-06",
                         "place": "Farmington, MO, USA",
                         "span": "0 days",
@@ -794,20 +816,24 @@ class TestFamiliesHandle(unittest.TestCase):
                 "father": {
                     "birth": {
                         "age": "0 days",
+                        "citations": 0,
+                        "confidence": 0,
                         "date": "1955-07-31",
                         "place": "Ottawa, La Salle, IL, USA",
                         "type": "Birth",
                     },
                     "death": {},
-                    "handle": "KLTJQC70XVZJSPQ43U",
                     "gramps_id": "I0017",
+                    "handle": "KLTJQC70XVZJSPQ43U",
                     "name_given": "Gerard Stephen",
                     "name_surname": "Garner",
                     "sex": "M",
                 },
-                "handle": "7MTJQCHRUUYSUA8ABB",
                 "gramps_id": "F0033",
+                "handle": "7MTJQCHRUUYSUA8ABB",
                 "marriage": {
+                    "citations": 0,
+                    "confidence": 0,
                     "date": "1979-01-06",
                     "place": "Farmington, MO, USA",
                     "span": "0 days",
@@ -816,18 +842,19 @@ class TestFamiliesHandle(unittest.TestCase):
                 "mother": {
                     "birth": {
                         "age": "0 days",
+                        "citations": 0,
+                        "confidence": 0,
                         "date": "1957-01-31",
                         "place": "",
                         "type": "Birth",
                     },
                     "death": {},
-                    "handle": "JFWJQCRREDFKZLDKVD",
                     "gramps_id": "I0123",
+                    "handle": "JFWJQCRREDFKZLDKVD",
                     "name_given": "Elizabeth",
                     "name_surname": "George",
                     "sex": "F",
                 },
-                "relationship": "Married",
                 "references": {
                     "person": [
                         {
@@ -884,6 +911,7 @@ class TestFamiliesHandle(unittest.TestCase):
                         },
                     ]
                 },
+                "relationship": "Married",
             },
         )
 
@@ -947,7 +975,7 @@ class TestFamiliesHandleTimeline(unittest.TestCase):
         """Test conforms to schema."""
         check_conforms_to_schema(
             self,
-            TEST_URL + "9OUJQCBOHW9UEK9CNV/timeline",
+            TEST_URL + "9OUJQCBOHW9UEK9CNV/timeline?ratings=1",
             "TimelineEventProfile",
         )
 
@@ -1095,3 +1123,9 @@ class TestFamiliesHandleTimeline(unittest.TestCase):
         for event in rv:
             if event["type"] == "Burial":
                 count = count + 1
+
+    def test_get_families_handle_timeline_parameter_ratings_validate_semantics(self):
+        """Test invalid ratings parameter and values."""
+        check_invalid_semantics(
+            self, TEST_URL + "9OUJQCBOHW9UEK9CNV/timeline?ratings", check="boolean"
+        )

--- a/tests/test_endpoints/test_people.py
+++ b/tests/test_endpoints/test_people.py
@@ -507,27 +507,41 @@ class TestPeople(unittest.TestCase):
         self.assertEqual(
             rv[0]["profile"],
             {
-                "birth": {"age": "0 days", "date": "570-04-19", "type": "Birth"},
+                "birth": {
+                    "age": "0 days",
+                    "citations": 0,
+                    "confidence": 0,
+                    "date": "570-04-19",
+                    "type": "Birth",
+                },
                 "death": {
                     "age": "62 years, 1 months, 19 days",
+                    "citations": 0,
+                    "confidence": 0,
                     "date": "632-06-08",
                     "type": "Death",
                 },
                 "events": [
                     {
                         "age": "0 days",
+                        "citations": 0,
+                        "confidence": 0,
                         "date": "570-04-19",
                         "role": "Primary",
                         "type": "Birth",
                     },
                     {
                         "age": "62 years, 1 months, 19 days",
+                        "citations": 0,
+                        "confidence": 0,
                         "date": "632-06-08",
                         "role": "Primary",
                         "type": "Death",
                     },
                     {
                         "age": "39 years, 8 months, 13 days",
+                        "citations": 0,
+                        "confidence": 0,
                         "date": "610",
                         "role": "Primary",
                         "type": "Marriage",
@@ -538,11 +552,15 @@ class TestPeople(unittest.TestCase):
                         "father": {
                             "birth": {
                                 "age": "0 days",
+                                "citations": 0,
+                                "confidence": 0,
                                 "date": "570-04-19",
                                 "type": "Birth",
                             },
                             "death": {
                                 "age": "62 years, 1 months, 19 days",
+                                "citations": 0,
+                                "confidence": 0,
                                 "date": "632-06-08",
                                 "type": "Death",
                             },
@@ -585,11 +603,15 @@ class TestPeople(unittest.TestCase):
                         "father": {
                             "birth": {
                                 "age": "0 days",
+                                "citations": 0,
+                                "confidence": 0,
                                 "date": "570-04-19",
                                 "type": "Birth",
                             },
                             "death": {
                                 "age": "62 years, 1 months, 19 days",
+                                "citations": 0,
+                                "confidence": 0,
                                 "date": "632-06-08",
                                 "type": "Death",
                             },
@@ -1049,7 +1071,7 @@ class TestPeopleHandleTimeline(unittest.TestCase):
         """Test conforms to schema."""
         check_conforms_to_schema(
             self,
-            TEST_URL + "GNUJQCL9MD64AM56OH/timeline",
+            TEST_URL + "GNUJQCL9MD64AM56OH/timeline?ratings=1",
             "TimelineEventProfile",
         )
 
@@ -1318,3 +1340,9 @@ class TestPeopleHandleTimeline(unittest.TestCase):
             if event["label"] == "Marriage (Stepsister)":
                 count = count + 1
         self.assertEqual(count, 4)
+
+    def test_get_people_handle_timeline_parameter_ratings_validate_semantics(self):
+        """Test invalid ratings parameter and values."""
+        check_invalid_semantics(
+            self, TEST_URL + "1QTJQCP5QMT2X7YJDK/timeline?ratings", check="boolean"
+        )

--- a/tests/test_endpoints/test_timelines.py
+++ b/tests/test_endpoints/test_timelines.py
@@ -54,7 +54,9 @@ class TestTimelinesPeople(unittest.TestCase):
 
     def test_get_timelines_people_conforms_to_schema(self):
         """Test conforms to schema."""
-        check_conforms_to_schema(self, TEST_URL + "people/", "TimelineEventProfile")
+        check_conforms_to_schema(
+            self, TEST_URL + "people/?ratings=1", "TimelineEventProfile"
+        )
 
     def test_get_timelines_people_expected_results(self):
         """Test some expected results returned."""
@@ -254,6 +256,10 @@ class TestTimelinesPeople(unittest.TestCase):
         for item in rv:
             self.assertIn(item["type"], ["Birth", "Death", "Burial"])
 
+    def test_get_timelines_people_parameter_ratings_validate_semantics(self):
+        """Test invalid ratings parameter and values."""
+        check_invalid_semantics(self, TEST_URL + "people/?ratings", check="boolean")
+
     def test_get_timelines_people_parameter_handles_missing_content(self):
         """Test missing content response."""
         check_resource_missing(self, TEST_URL + "people/?handles=not_a_real_handle")
@@ -308,7 +314,9 @@ class TestTimelinesFamilies(unittest.TestCase):
 
     def test_get_timelines_families_conforms_to_schema(self):
         """Test conforms to schema."""
-        check_conforms_to_schema(self, TEST_URL + "families/", "TimelineEventProfile")
+        check_conforms_to_schema(
+            self, TEST_URL + "families/?ratings=1", "TimelineEventProfile"
+        )
 
     def test_get_timelines_families_expected_results(self):
         """Test some expected results returned."""
@@ -455,6 +463,10 @@ class TestTimelinesFamilies(unittest.TestCase):
         rv = check_success(self, TEST_URL + "families/?keys=type&event_classes=vital")
         for item in rv:
             self.assertIn(item["type"], ["Birth", "Death", "Burial"])
+
+    def test_get_timelines_families_parameter_ratings_validate_semantics(self):
+        """Test invalid ratings parameter and values."""
+        check_invalid_semantics(self, TEST_URL + "families/?ratings", check="boolean")
 
     def test_get_timelines_families_parameter_handles_missing_content(self):
         """Test missing content response."""


### PR DESCRIPTION
@DavidMStraub this one adds a "ratings" query parm to the timeline endpoints and a ratings keyword to the profile query parms and includes ratings when profile=all.  The rating information is for event information, two keywords are provided. The citations one is the number of citations for the event, and the confidence one is the highest available confidence level among the citations. 

If you have ever played with [Rootsfinder](https://www.rootsfinder.com/) Dallan added stars next to different events using one star for each citation, the idea being to provide a visual cue as to how well sourced the information was.  So the idea is that this information could be used to do something similar possibly. I included confidence as you could have 6 sources but they could all be relatively poor, and so six stars is deceiving in that scenario. So the thinking being maybe you then color code by confidence level.