### PR TITLE
Refactor /api/translations add native language names (Closes #150)

### DIFF
--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -3709,11 +3709,33 @@ paths:
       operationId: getTranslations
       security:
         - Bearer: []
+      parameters:
+      - name: locale
+        in: query
+        required: false
+        type: string
+        description: "Specifies the language code of the locale to be used as the current locale."
+      - name: sort
+        in: query
+        required: false
+        type: string
+        default: "language"
+        description: >
+          A comma delimited list of keys to sort the result set by.  By default the sort is in ascending order, if the key name starts with a - sign then the sort will be in descending order.  For translations the available keys are:
+
+            Key | Description
+            --- | -----------
+            current | The name of the language in the current locale
+            default | The name of the language in the default locale
+            language | The language code
+            native | The native name of the language in it's own locale
       responses:
         200:
           description: "OK: Successful operation."
           schema:
-            $ref: "#/definitions/Translations"
+            type: array
+            items:
+              $ref: "#/definitions/Language"
         401:
           description: "Unauthorized: Missing authorization header."
 
@@ -7104,14 +7126,25 @@ definitions:
 # Model - Translations
 ##############################################################################
 
-  Translations:
+  Language:
     type: object
-    additionalProperties:
-      type: string
-    example:
-      ar: Arabic
-      bg: Bulgarian
-      ca: Catalan
+    properties:
+      current:
+        description: "The language name in the current locale."
+        type: string
+        example: "Bulgarisch"
+      default:
+        description: "The language name in the default locale."
+        type: string
+        example: "Bulgarian"
+      language:
+        description: "The language code."
+        type: string
+        example: "bg"
+      native:
+        description: "The language name in the native locale of the language."
+        type: string
+        example: "Български"
 
 ##############################################################################
 # Model - Translation

--- a/tests/test_endpoints/test_translations.py
+++ b/tests/test_endpoints/test_translations.py
@@ -54,15 +54,7 @@ class TestTranslations(unittest.TestCase):
 
     def test_get_translations_conforms_to_schema(self):
         """Test conformity to schema."""
-        check_conforms_to_schema(self, TEST_URL, "Translations")
-
-    def test_get_translations_expected_result(self):
-        """Test some minimum set of expected values returned."""
-        rv = check_success(self, TEST_URL)
-        self.assertIsInstance(rv, type({}))
-        self.assertGreaterEqual(len(rv), 39)
-        self.assertIn("ar", rv)
-        self.assertIn("zh_TW", rv)
+        check_conforms_to_schema(self, TEST_URL, "Language")
 
 
 class TestTranslationsLanguage(unittest.TestCase):


### PR DESCRIPTION
Hey David, this should close #150  Note you now get back a list and you can sort on any of the four fields as you please.  You may also pass an optional locale= as well. 

![Screenshot from 2020-12-25 20-59-44](https://user-images.githubusercontent.com/43528418/103144273-81e27a80-46f4-11eb-99c8-73e0cab834d8.png)

