### PR TITLE
Catch handle error in search (fixes #145); fix missing attribute in index 

### DIFF
--- a/gramps_webapi/api/resources/user.py
+++ b/gramps_webapi/api/resources/user.py
@@ -160,7 +160,7 @@ def handle_reset_token(username: str, email: str, token: str):
 
 Please click on the following link, or paste this into your browser to complete the process:
 
-{}/api/users/-/password/reset?jwt={}
+{}/api/users/-/password/reset/?jwt={}
 
 If you did not request this, please ignore this e-mail and your password will remain unchanged.
 """.format(

--- a/gramps_webapi/api/search.py
+++ b/gramps_webapi/api/search.py
@@ -141,6 +141,7 @@ class SearchIndexer:
                     writer.add_document(
                         type=obj_dict["class_name"].lower(),
                         handle=obj_dict["handle"],
+                        private=obj_dict["private"],
                         text=obj_dict["string"],
                         text_private=obj_dict["string_private"],
                         change=obj_dict["change"],


### PR DESCRIPTION
This closes #145 by catching possible handle errors in sort (e.g. when the index returns a hit to an object that has been removed from the DB after indexing).

It also fixes another bug I noticed: the `private` attribute was not properly stored in the index so #111 did not work properly.