### PR TITLE
Add dates parameter support for events and timelines

### DIFF
--- a/gramps_webapi/api/resources/match.py
+++ b/gramps_webapi/api/resources/match.py
@@ -1,0 +1,88 @@
+#
+# Gramps Web API - A RESTful API for the Gramps genealogy program
+#
+# Copyright (C) 2020      Christopher Horn
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Matching utilities."""
+from typing import List
+
+from gramps.gen.db.base import DbReadBase
+from gramps.gen.lib import Date
+from gramps.gen.lib.date import gregorian
+
+from ...types import Handle
+
+
+def match_date(date: Date, mask: str) -> bool:
+    """Check if date matches mask."""
+    if date is not None and date.is_valid():
+        year_mask, month_mask, day_mask = mask.split("/")
+        date = gregorian(date)
+        year = date.get_year()
+        if year_mask == "*" or year == int(year_mask):
+            month = date.get_month()
+            if month_mask == "*" or month == int(month_mask):
+                day = date.get_day()
+                if day_mask == "*" or day == int(day_mask):
+                    return True
+    return False
+
+
+def match_date_range(date: Date, start_date: Date, end_date: Date) -> bool:
+    """Check if date falls in given range."""
+    if start_date:
+        if start_date.match(date, comparison=">"):
+            return False
+    if end_date:
+        if end_date.match(date, comparison="<"):
+            return False
+    return True
+
+
+def match_dates(
+    db_handle: DbReadBase, gramps_class_name: str, handles: List[Handle], date_mask: str
+):
+    """Match dates based on a date mask or range."""
+    check_range = False
+    if "-" in date_mask:
+        check_range = True
+        start, end = date_mask.split("-")
+        if "/" in start:
+            year, month, day = start.split("/")
+            start_date = Date((int(year), int(month), int(day)))
+        else:
+            start_date = None
+        if "/" in end:
+            year, month, day = end.split("/")
+            end_date = Date((int(year), int(month), int(day)))
+        else:
+            end_date = None
+
+    query_method = db_handle.method("get_%s_from_handle", gramps_class_name)
+    result = []
+    for handle in handles:
+        obj = query_method(handle)
+        date = obj.get_date_object()
+        if date.is_valid():
+            if check_range:
+                if match_date_range(date, start_date, end_date):
+                    result.append(handle)
+            else:
+                if match_date(date, date_mask):
+                    result.append(handle)
+    return result

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -671,18 +671,34 @@ paths:
         type: string
         minLength: 8
         description: "The unique identifier for a person."
+      - name: dates
+        in: query
+        required: false
+        type: string
+        description: >
+          A date range to bound the timeline that may be provided in one of three formats as follows:
+
+
+            Format | Description
+            ------ | -----------
+            -y/m/d | Match everything before the provided end date
+            y/m/d-y/m/d | Match everything in the given date range
+            y/m/d- | Match everthing after the provided start date
+
+
+          Note a person timeline is usually bounded by the first and last recorded event of their lives and this will override that behaviour. If this is not used the timeline boundaries can still be altered using the first and last parameters.
       - name: first
         in: query
         required: false
         type: boolean
         default: true
-        description: "Indicates whether or not events dated prior to the first event for the person should be discarded or not."
+        description: "Indicates whether or not events dated prior to the first event for the person should be discarded or not. Note if the dates parameter is used this has no effect."
       - name: last
         in: query
         required: false
         type: boolean
         default: true
-        description: "Indicates whether or not events dated after the last event for the person should be discarded or not."
+        description: "Indicates whether or not events dated after the last event for the person should be discarded or not. Note if the dates parameter is used this has no effect."
       - name: ancestors
         in: query
         required: false
@@ -1125,6 +1141,21 @@ paths:
         type: string
         minLength: 8
         description: "The unique identifier for a person."
+      - name: dates
+        in: query
+        required: false
+        type: string
+        description: >
+          A date range to bound the timeline that may be provided in one of three formats as follows:
+
+
+            Format | Description
+            ------ | -----------
+            -y/m/d | Match everything before the provided end date
+            y/m/d-y/m/d | Match everything in the given date range
+            y/m/d- | Match everthing after the provided start date
+
+          If not provided all events for all family members will be returned.
       - name: events
         in: query
         required: false
@@ -1250,6 +1281,20 @@ paths:
             place | The event place
             private | Indicates whether the record is private or not
             type | The event type
+      - name: dates
+        in: query
+        required: false
+        type: string
+        description: >
+          A date filter that operates on the event date and can accept an argument in one of four formats as follows:
+
+
+            Format | Description
+            ------ | -----------
+            y/m/d | Match the specific date or date pattern as * may be used to wild card an entry
+            -y/m/d | Match everything before the provided end date
+            y/m/d-y/m/d | Match everything in the given date range
+            y/m/d- | Match everthing after the provided start date
       - name: filter
         in: query
         required: false
@@ -1792,6 +1837,20 @@ paths:
             date | The date of the citation
             gramps_id | The user assigned Gramps identifier for the citation
             private | Indicates whether the record is private or not
+      - name: dates
+        in: query
+        required: false
+        type: string
+        description: >
+          A date filter that operates on the citation date and can accept an argument in one of four formats as follows:
+
+
+            Format | Description
+            ------ | -----------
+            y/m/d | Match the specific date or date pattern as * may be used to wild card an entry
+            -y/m/d | Match everything before the provided end date
+            y/m/d-y/m/d | Match everything in the given date range
+            y/m/d- | Match everthing after the provided start date
       - name: filter
         in: query
         required: false
@@ -2448,6 +2507,20 @@ paths:
             path | The path to the media item
             private | Indicates whether the record is private or not
             title | The title for the media item
+      - name: dates
+        in: query
+        required: false
+        type: string
+        description: >
+          A date filter that operates on the media item date and can accept an argument in one of four formats as follows:
+
+
+            Format | Description
+            ------ | -----------
+            y/m/d | Match the specific date or date pattern as * may be used to wild card an entry
+            -y/m/d | Match everything before the provided end date
+            y/m/d-y/m/d | Match everything in the given date range
+            y/m/d- | Match everthing after the provided start date
       - name: filter
         in: query
         required: false
@@ -3983,18 +4056,33 @@ paths:
         required: false
         type: string
         description: "If provided the handle of a person to anchor the timeline."
+      - name: dates
+        in: query
+        required: false
+        type: string
+        description: >
+          A date range to bound the timeline that may be provided in one of three formats as follows:
+
+
+            Format | Description
+            ------ | -----------
+            -y/m/d | Match everything before the provided end date
+            y/m/d-y/m/d | Match everything in the given date range
+            y/m/d- | Match everthing after the provided start date
+
+          Note if an anchor person was provided the timeline is usually bound by the first and last recorded event of their lives and this will override that behaviour. If this is not used and an anchor person is present the timeline boundaries can still be altered using the first and last parameters.
       - name: first
         in: query
         required: false
         type: boolean
         default: true
-        description: "If an anchor person was provided then indicates whether or not events dated prior to the first event for the anchor person should be discarded or not."
+        description: "If an anchor person was provided then indicates whether or not events dated prior to the first event for the anchor person should be discarded or not. Note if the dates parameter is used this has no effect."
       - name: last
         in: query
         required: false
         type: boolean
         default: true
-        description: "If an anchor person was provided then indicates whether or not events dated after the last event for the anchor person should be discarded or not."
+        description: "If an anchor person was provided then indicates whether or not events dated after the last event for the anchor person should be discarded or not. Note if the date parameter has been used this has no effect."
       - name: handles
         in: query
         required: false
@@ -4152,6 +4240,19 @@ paths:
         type: string
         minLength: 8
         description: "A comma delimited list of handles for specific families to put on the timeline. If not provided every family in the database is evaluated."
+      - name: dates
+        in: query
+        required: false
+        type: string
+        description: >
+          A date range to bound the timeline that may be provided in one of three formats as follows:
+
+
+            Format | Description
+            ------ | -----------
+            -y/m/d | Match everything before the provided end date
+            y/m/d-y/m/d | Match everything in the given date range
+            y/m/d- | Match everthing after the provided start date
       - name: filter
         in: query
         required: false

--- a/tests/test_endpoints/test_citations.py
+++ b/tests/test_endpoints/test_citations.py
@@ -336,6 +336,28 @@ class TestCitations(unittest.TestCase):
         rv = check_success(self, TEST_URL + "?page=1&keys=backlinks&backlinks=1")
         self.assertIn("a5af0ecb107303354a0", rv[0]["backlinks"]["event"])
 
+    def test_get_citations_parameter_dates_validate_semantics(self):
+        """Test invalid dates parameter and values."""
+        check_invalid_semantics(self, TEST_URL + "?dates", check="list")
+        check_invalid_semantics(self, TEST_URL + "?dates=/1/1")
+        check_invalid_semantics(self, TEST_URL + "?dates=1900//1")
+        check_invalid_semantics(self, TEST_URL + "?dates=1900/1/")
+        check_invalid_semantics(self, TEST_URL + "?dates=1900/a/1")
+        check_invalid_semantics(self, TEST_URL + "?dates=-1900/a/1")
+        check_invalid_semantics(self, TEST_URL + "?dates=1900/a/1-")
+        check_invalid_semantics(self, TEST_URL + "?dates=1855/1/1-1900/*/1")
+
+    def test_get_citations_parameter_dates_expected_result(self):
+        """Test dates parameter expected results."""
+        rv = check_success(self, TEST_URL + "?dates=1855/*/*")
+        self.assertEqual(len(rv), 2)
+        rv = check_success(self, TEST_URL + "?dates=-1900/1/1")
+        self.assertEqual(len(rv), 2)
+        rv = check_success(self, TEST_URL + "?dates=1900/1/1-")
+        self.assertEqual(len(rv), 1)
+        rv = check_success(self, TEST_URL + "?dates=1855/1/1-1900/12/31")
+        self.assertEqual(len(rv), 2)
+
 
 class TestCitationsHandle(unittest.TestCase):
     """Test cases for the /api/citations/{handle} endpoint for a specific citation."""

--- a/tests/test_endpoints/test_events.py
+++ b/tests/test_endpoints/test_events.py
@@ -443,6 +443,28 @@ class TestEvents(unittest.TestCase):
         rv = check_boolean_parameter(self, TEST_URL + "?page=1", "backlinks", join="&")
         self.assertIn("66TJQC6CC7ZWL9YZ64", rv[0]["backlinks"]["person"])
 
+    def test_get_events_parameter_dates_validate_semantics(self):
+        """Test invalid dates parameter and values."""
+        check_invalid_semantics(self, TEST_URL + "?dates", check="list")
+        check_invalid_semantics(self, TEST_URL + "?dates=/1/1")
+        check_invalid_semantics(self, TEST_URL + "?dates=1900//1")
+        check_invalid_semantics(self, TEST_URL + "?dates=1900/1/")
+        check_invalid_semantics(self, TEST_URL + "?dates=1900/a/1")
+        check_invalid_semantics(self, TEST_URL + "?dates=-1900/a/1")
+        check_invalid_semantics(self, TEST_URL + "?dates=1900/a/1-")
+        check_invalid_semantics(self, TEST_URL + "?dates=1855/1/1-1900/*/1")
+
+    def test_get_events_parameter_dates_expected_result(self):
+        """Test dates parameter expected results."""
+        rv = check_success(self, TEST_URL + "?dates=*/1/1")
+        self.assertEqual(len(rv), 8)
+        rv = check_success(self, TEST_URL + "?dates=-1855/1/1")
+        self.assertEqual(len(rv), 933)
+        rv = check_success(self, TEST_URL + "?dates=1855/1/1-")
+        self.assertEqual(len(rv), 1203)
+        rv = check_success(self, TEST_URL + "?dates=1855/1/1-1900/12/31")
+        self.assertEqual(len(rv), 300)
+
 
 class TestEventsHandle(unittest.TestCase):
     """Test cases for the /api/events/{handle} endpoint for a specific event."""

--- a/tests/test_endpoints/test_media.py
+++ b/tests/test_endpoints/test_media.py
@@ -349,6 +349,28 @@ class TestMedia(unittest.TestCase):
         )
         self.assertIn("9OUJQCBOHW9UEK9CNV", rv[0]["backlinks"]["family"])
 
+    def test_get_media_parameter_dates_validate_semantics(self):
+        """Test invalid dates parameter and values."""
+        check_invalid_semantics(self, TEST_URL + "?dates", check="list")
+        check_invalid_semantics(self, TEST_URL + "?dates=/1/1")
+        check_invalid_semantics(self, TEST_URL + "?dates=1900//1")
+        check_invalid_semantics(self, TEST_URL + "?dates=1900/1/")
+        check_invalid_semantics(self, TEST_URL + "?dates=1900/a/1")
+        check_invalid_semantics(self, TEST_URL + "?dates=-1900/a/1")
+        check_invalid_semantics(self, TEST_URL + "?dates=1900/a/1-")
+        check_invalid_semantics(self, TEST_URL + "?dates=1855/1/1-1900/*/1")
+
+    def test_get_media_parameter_dates_expected_result(self):
+        """Test dates parameter expected results."""
+        rv = check_success(self, TEST_URL + "?dates=1897/*/*")
+        self.assertEqual(len(rv), 1)
+        rv = check_success(self, TEST_URL + "?dates=-1900/1/1")
+        self.assertEqual(len(rv), 1)
+        rv = check_success(self, TEST_URL + "?dates=1900/1/1-")
+        self.assertEqual(len(rv), 0)
+        rv = check_success(self, TEST_URL + "?dates=1855/1/1-1900/12/31")
+        self.assertEqual(len(rv), 1)
+
 
 class TestMediaHandle(unittest.TestCase):
     """Test cases for the /api/media/{handle} endpoint for specific media."""

--- a/tests/test_endpoints/test_timelines.py
+++ b/tests/test_endpoints/test_timelines.py
@@ -272,6 +272,27 @@ class TestTimelinesPeople(unittest.TestCase):
                 item["person"]["name_given"], ["Lewis Anderson", "Howard Lane"]
             )
 
+    def test_get_timelines_people_parameter_dates_validate_semantics(self):
+        """Test invalid dates parameter and values."""
+        check_invalid_semantics(self, TEST_URL + "people/?dates", check="list")
+        check_invalid_semantics(self, TEST_URL + "people/?dates=/1/1")
+        check_invalid_semantics(self, TEST_URL + "people/?dates=1900//1")
+        check_invalid_semantics(self, TEST_URL + "people/?dates=1900/1/")
+        check_invalid_semantics(self, TEST_URL + "people/?dates=1900/a/1")
+        check_invalid_semantics(self, TEST_URL + "people/?dates=-1900/a/1")
+        check_invalid_semantics(self, TEST_URL + "people/?dates=1900/a/1-")
+        check_invalid_semantics(self, TEST_URL + "people/?dates=1855/1/1-1900/*/1")
+        check_invalid_semantics(self, TEST_URL + "people/?dates=1855/*/*")
+
+    def test_get_timelines_people_parameter_dates_expected_result(self):
+        """Test dates parameter expected results."""
+        rv = check_success(self, TEST_URL + "people/?dates=-1900/1/1")
+        self.assertEqual(len(rv), 1235)
+        rv = check_success(self, TEST_URL + "people/?dates=1900/1/1-")
+        self.assertEqual(len(rv), 903)
+        rv = check_success(self, TEST_URL + "people/?dates=1855/1/1-1900/12/31")
+        self.assertEqual(len(rv), 300)
+
 
 class TestTimelinesFamilies(unittest.TestCase):
     """Test cases for the /api/timelines/families endpoint for a group of families."""
@@ -447,3 +468,24 @@ class TestTimelinesFamilies(unittest.TestCase):
         """Test handles parameter for expected results."""
         rv = check_success(self, TEST_URL + "families/?handles=9OUJQCBOHW9UEK9CNV")
         self.assertEqual(len(rv), 33)
+
+    def test_get_timelines_families_parameter_dates_validate_semantics(self):
+        """Test invalid dates parameter and values."""
+        check_invalid_semantics(self, TEST_URL + "families/?dates", check="list")
+        check_invalid_semantics(self, TEST_URL + "families/?dates=/1/1")
+        check_invalid_semantics(self, TEST_URL + "families/?dates=1900//1")
+        check_invalid_semantics(self, TEST_URL + "families/?dates=1900/1/")
+        check_invalid_semantics(self, TEST_URL + "families/?dates=1900/a/1")
+        check_invalid_semantics(self, TEST_URL + "families/?dates=-1900/a/1")
+        check_invalid_semantics(self, TEST_URL + "families/?dates=1900/a/1-")
+        check_invalid_semantics(self, TEST_URL + "families/?dates=1855/1/1-1900/*/1")
+        check_invalid_semantics(self, TEST_URL + "families/?dates=1855/*/*")
+
+    def test_get_timelines_families_parameter_dates_expected_result(self):
+        """Test dates parameter expected results."""
+        rv = check_success(self, TEST_URL + "families/?dates=-1900/1/1")
+        self.assertEqual(len(rv), 1214)
+        rv = check_success(self, TEST_URL + "families/?dates=1900/1/1-")
+        self.assertEqual(len(rv), 885)
+        rv = check_success(self, TEST_URL + "families/?dates=1855/1/1-1900/12/31")
+        self.assertEqual(len(rv), 290)


### PR DESCRIPTION
@DavidMStraub I think this is ready now.  As citations and media objects are dated it operates on those in addition to events and I also added it to the timeline endpoints but with no wildcard support as it makes no sense there. If used with a timeline and the timeline has an anchor person it takes precedence with regard to setting the boundaries.

So valid arguments are things like `*/12/28` or `1900/1/*` or `1900/*/*` as suggested, but you can also do things like `-1900/1/1` for all events before that date, `1900/1/1-` for all events after that date, and `1855/1/1-1900/1/1` for all events in that range.

The apispec.yaml is updated and threw in some unit tests.