### PR TITLE
Remove reindex from app factory (fixes #149)

### DIFF
--- a/tests/test_endpoints/__init__.py
+++ b/tests/test_endpoints/__init__.py
@@ -71,6 +71,10 @@ def setUpModule():
         test_app = create_app(db_manager=test_db)
     test_app.config["TESTING"] = True
     TEST_CLIENT = test_app.test_client()
+    search_index = test_app.config["SEARCH_INDEXER"]
+    db = test_db.get_db().db
+    search_index.reindex_full(db)
+    db.close()
     sqlauth = test_app.config["AUTH_PROVIDER"]
     sqlauth.create_table()
     for role in TEST_USERS:


### PR DESCRIPTION
As argued in #149 it was not such a good idea to put the search reindexing into the app factory. I removed it now and added a service script instead, which can be run e.g. like:

```
python3 -m gramps_webapi --config config.cfg search index-full
```

The next step in a separate PR will be to implement incremental indexing.

