### PR TITLE
Add docker build pipeline

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,134 @@
+Pipfile
+Pipfile.lock
+.venv
+*.ipynb
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -1,0 +1,31 @@
+name: build image
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          install: true
+      - name: Builder instance name
+        run: echo ${{ steps.buildx.outputs.name }}
+      - name: Available platforms
+        run: echo ${{ steps.buildx.outputs.platforms }}
+      - name: login to docker hub
+        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+      - name: build the image
+        run: |
+          docker build --push \
+            --tag dmstraub/gramps-webapi:latest \
+            --platform linux/amd64,linux/arm/v7,linux/arm64 .

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,5 +29,5 @@ RUN python3 -m pip install --no-cache-dir --extra-index-url https://www.piwheels
     /app/src
 
 EXPOSE 5000
-ENTRYPOINT ./src/docker-entrypoint.sh
+
 CMD gunicorn -w 8 -b 0.0.0.0:5000 gramps_webapi.wsgi:app --timeout 120

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM dmstraub/gramps:latest
+
+WORKDIR /app
+ENV PYTHONPATH="${PYTHONPATH}:/usr/lib/python3/dist-packages"
+
+# set locale
+RUN localedef -i en_GB -c -f UTF-8 -A /usr/share/locale/locale.alias en_GB.UTF-8
+ENV LANGUAGE en_GB.utf8
+ENV LANG en_GB.utf8
+ENV LC_ALL en_GB.utf8
+
+ENV GRAMPS_API_CONFIG=/app/config/config.cfg
+
+# create directories
+RUN mkdir /app/src &&  mkdir /app/config && touch /app/config/config.cfg
+RUN mkdir /app/static && touch /app/static/index.html
+RUN mkdir /app/db && mkdir /app/media && mkdir /app/indexdir && mkdir /app/users
+
+# install gunicorn
+RUN python3 -m pip install --no-cache-dir --extra-index-url https://www.piwheels.org/simple \
+    gunicorn
+
+# copy package source and install
+COPY . /app/src
+RUN python3 -m pip install --no-cache-dir --extra-index-url https://www.piwheels.org/simple \
+    /app/src
+
+EXPOSE 5000
+ENTRYPOINT ./src/docker-entrypoint.sh
+CMD gunicorn -w 8 -b 0.0.0.0:5000 gramps_webapi.wsgi:app --timeout 120

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ FROM dmstraub/gramps:latest
 WORKDIR /app
 ENV PYTHONPATH="${PYTHONPATH}:/usr/lib/python3/dist-packages"
 
+# install poppler (needed for PDF thumbnails)
+RUN apt-get update && apt-get install -y poppler-utils && rm -rf /var/lib/apt/lists/*
+
 # set locale
 RUN localedef -i en_GB -c -f UTF-8 -A /usr/share/locale/locale.alias en_GB.UTF-8
 ENV LANGUAGE en_GB.utf8

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-set -e
-
-python3 -m gramps_webapi --config /app/config/config.cfg search index-full
-
-exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+python3 -m gramps_webapi --config /app/config/config.cfg search index-full
+
+exec "$@"


### PR DESCRIPTION
To simplify deployment, this PR adds an automated docker build pipeline. I am already using this to publish a Gramps docker image on Docker Hub using Github actions, see here: https://github.com/DavidMStraub/gramps-docker. It creates a multiarch image that also runs on ARM (which is important for me since I host the app on a Raspberry Pi and suspect this might be attractive for many people). It follows closely [this blog post](https://www.docker.com/blog/multi-arch-build-and-images-the-simple-way/).

Based on the Gramps base image, here I added a dockerfile which installs the Web API Python package directly from the repository. It also re-generates the full-text search index on container start (this will work after meging #160). It uses `gunicorn` as a WSGI server.

Every push to the `master` branch will automatically push the new images to Docker hub. It requires to setup the Docker Hub deploy token in the Github repo settings, I will send the token separetly to @Nick-Hall.

Based on this image, we can then provide deployment instructions (#161) which will be as simple as modifying a `docker-compose.yml` file.