### PR TITLE
Limit relation search depth, estimate death date if needed

### DIFF
--- a/gramps_webapi/api/resources/timeline.py
+++ b/gramps_webapi/api/resources/timeline.py
@@ -476,7 +476,8 @@ class Timeline:
                             person_age = self.get_age(
                                 self.birth_dates[event[1].handle], event[0].date
                             )
-                            age = person_age
+                            if not age:
+                                age = person_age
                     person["age"] = person_age
 
             profile = {

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -7998,7 +7998,11 @@ definitions:
     type: object
     properties:
       age:
-        description: "The age of the person the timeline is for at the time of the event."
+        description: >
+          The age of the person at the time of the event. If the timeline is anchored, that is
+          for a specific person, then it is their age at the time of the event. If the timeline
+          is not anchored then it is the age of the person associated with that event at the
+          time of the event.
         type: string
         example: "2 years"
       citations:
@@ -8052,6 +8056,10 @@ definitions:
   TimelinePersonProfile:
     type: object
     properties:
+      age:
+        description: "The age of the person at the time of the event."
+        type: string
+        example: "2 years"
       birth:
         description: "The birth event profile, or best fallback such as baptism, of the person."
         type: object

--- a/tests/test_endpoints/test_people.py
+++ b/tests/test_endpoints/test_people.py
@@ -1214,7 +1214,7 @@ class TestPeopleHandleTimeline(unittest.TestCase):
         """Test precision parameter for expected results."""
         rv = check_success(self, TEST_URL + "1QTJQCP5QMT2X7YJDK/timeline?precision=3")
         self.assertEqual(rv[8]["label"], "Death (Mother)")
-        self.assertEqual(rv[8]["span"], "22 years, 3 months, 23 days")
+        self.assertEqual(rv[8]["age"], "22 years, 3 months, 23 days")
 
     def test_get_people_handle_timeline_parameter_first_validate_semantics(self):
         """Test invalid first parameter and values."""

--- a/tests/test_endpoints/test_timelines.py
+++ b/tests/test_endpoints/test_timelines.py
@@ -200,7 +200,7 @@ class TestTimelinesPeople(unittest.TestCase):
             self, TEST_URL + "people/?anchor=GNUJQCL9MD64AM56OH&precision=3"
         )
         self.assertEqual(rv[11]["label"], "Birth")
-        self.assertEqual(rv[11]["span"], "2 years, 6 months, 1 days")
+        self.assertEqual(rv[11]["age"], "2 years, 6 months, 1 days")
 
     def test_get_timelines_people_parameter_first_validate_semantics(self):
         """Test invalid first parameter and values."""


### PR DESCRIPTION
@DavidMStraub I hope this addresses #164 and #165  I choose to use `probably_alive` for the calculation of the death date to bound with if no event indicating death is identifiable for the anchor person. For the relationship calculator the depth is set to `max(ancestors, offspring) + 1`