### PR TITLE
Implement thumbnail caching (#126)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ ENV GRAMPS_API_CONFIG=/app/config/config.cfg
 RUN mkdir /app/src &&  mkdir /app/config && touch /app/config/config.cfg
 RUN mkdir /app/static && touch /app/static/index.html
 RUN mkdir /app/db && mkdir /app/media && mkdir /app/indexdir && mkdir /app/users
+RUN mkdir /app/thumbnail_cache
 
 # install gunicorn
 RUN python3 -m pip install --no-cache-dir --extra-index-url https://www.piwheels.org/simple \

--- a/gramps_webapi/api/util.py
+++ b/gramps_webapi/api/util.py
@@ -186,7 +186,6 @@ def make_cache_key_thumbnails(*args, **kwargs):
     # checksum in the DB
     checksum = obj.checksum
 
-    print(checksum, request.path, arg_hash)
     cache_key = checksum + request.path + arg_hash
 
     return cache_key

--- a/gramps_webapi/app.py
+++ b/gramps_webapi/app.py
@@ -28,7 +28,7 @@ from flask_compress import Compress
 from flask_cors import CORS
 from flask_jwt_extended import JWTManager
 
-from .api import api_blueprint
+from .api import api_blueprint, thumbnail_cache
 from .api.resources.token import limiter
 from .api.search import SearchIndexer
 from .auth import SQLAuth
@@ -68,6 +68,8 @@ def create_app(db_manager=None):
         if not app.config.get("USER_DB_URI"):
             raise ValueError("USER_DB_URI must be specified")
         app.config["AUTH_PROVIDER"] = SQLAuth(db_uri=app.config["USER_DB_URI"])
+
+    thumbnail_cache.init_app(app, config=app.config["THUMBNAIL_CACHE_CONFIG"])
 
     # search indexer
     app.config["SEARCH_INDEXER"] = SearchIndexer(app.config["SEARCH_INDEX_DIR"])

--- a/gramps_webapi/config.py
+++ b/gramps_webapi/config.py
@@ -37,6 +37,11 @@ class DefaultConfig(object):
     BASE_URL = "http://localhost/"
     CORS_EXPOSE_HEADERS = ["X-Total-Count"]
     STATIC_PATH = "static"
+    THUMBNAIL_CACHE_CONFIG = {
+        "CACHE_TYPE": "filesystem",
+        "CACHE_DIR": "thumbnail_cache",
+        "CACHE_THRESHOLD": 1000,
+    }
 
 
 class DefaultConfigJWT(object):

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ with open("gramps_webapi/_version.py") as version_file:
 REQUIREMENTS = [
     "Click>=7.0",
     "Flask",
+    "Flask-Caching",
     "Flask-Compress",
     "Flask-Cors",
     "Flask-JWT-Extended",


### PR DESCRIPTION
In my deployment I am already in trouble with high CPU usage, most likely due to constant thumbnail regeneration. This PR addresses this issue.

I didn't use naive caching by query string as in the "old" backend since I realized the following problems:

- It also uses the JWT as key which changes every 15 minutes
- It would serve cached private media files to unauthorized users (if they know/guess the handle)
- It wouldn't detect media objects with modified file, but unchanged handle

To solve all three problems, I now use a custom cache key which uses the MD5 hash from the Gramps DB, the request path *and* the hashed query arguments but *without* the JWT. By using the MD5 hash from the DB, we can abort for unauthorized users (since the private proxy DB will not contain the handle) and at the same time not serve outdated files.