### PR TITLE
Implement API changes of Flask-JWT-Extended 2.0 (fixes #175)

### DIFF
--- a/gramps_webapi/api/auth.py
+++ b/gramps_webapi/api/auth.py
@@ -24,11 +24,7 @@ from functools import wraps
 from typing import Iterable
 
 from flask import abort, current_app
-from flask_jwt_extended import (
-    get_jwt_claims,
-    verify_jwt_in_request,
-    verify_jwt_refresh_token_in_request,
-)
+from flask_jwt_extended import get_jwt, verify_jwt_in_request
 
 
 def jwt_required_ifauth(func):
@@ -49,7 +45,7 @@ def jwt_refresh_token_required_ifauth(func):
     @wraps(func)
     def wrapper(*args, **kwargs):
         if not current_app.config.get("DISABLE_AUTH"):
-            verify_jwt_refresh_token_in_request()
+            verify_jwt_in_request(refresh=True)
         return func(*args, **kwargs)
 
     return wrapper
@@ -59,7 +55,7 @@ def has_permissions(scope: Iterable[str]) -> bool:
     """Check a set of permissions and return False if any are missing."""
     if current_app.config.get("DISABLE_AUTH"):
         return True
-    claims = get_jwt_claims()
+    claims = get_jwt()
     user_permissions = set(claims.get("permissions", []))
     required_permissions = set(scope)
     missing_permissions = required_permissions - user_permissions

--- a/gramps_webapi/api/file.py
+++ b/gramps_webapi/api/file.py
@@ -93,9 +93,7 @@ class LocalFileHandler(FileHandler):
 
     def send_file(self):
         """Send media file to client."""
-        return send_from_directory(
-            directory=self.base_dir, filename=self.path_rel, mimetype=self.mime
-        )
+        return send_from_directory(self.base_dir, self.path_rel, mimetype=self.mime)
 
     def send_cropped(self, x1: int, y1: int, x2: int, y2: int, square: bool = False):
         """Send cropped image."""

--- a/gramps_webapi/api/resources/token.py
+++ b/gramps_webapi/api/resources/token.py
@@ -43,7 +43,7 @@ def get_tokens(
 ):
     """Create access token (and refresh token if desired)."""
     access_token = create_access_token(
-        identity=username, user_claims={"permissions": list(permissions)}
+        identity=username, additional_claims={"permissions": list(permissions)}
     )
     if not include_refresh:
         return {"access_token": access_token}

--- a/gramps_webapi/api/resources/user.py
+++ b/gramps_webapi/api/resources/user.py
@@ -23,7 +23,7 @@
 import datetime
 
 from flask import abort, current_app, jsonify, render_template
-from flask_jwt_extended import create_access_token, get_jwt_claims, get_jwt_identity
+from flask_jwt_extended import create_access_token, get_jwt, get_jwt_identity
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
 from webargs import fields
@@ -191,7 +191,7 @@ class UserTriggerResetPasswordResource(Resource):
             identity=user_name,
             # the hash of the existing password is stored in the token in order
             # to make sure the rest token can only be used once
-            user_claims={"old_hash": auth_provider.get_pwhash(user_name)},
+            additional_claims={"old_hash": auth_provider.get_pwhash(user_name)},
             # password reset has to be triggered within 1h
             expires_delta=datetime.timedelta(hours=1),
         )
@@ -215,7 +215,7 @@ class UserResetPasswordResource(ProtectedResource):
             abort(405)
         if args["new_password"] == "":
             abort(400)
-        claims = get_jwt_claims()
+        claims = get_jwt()
         username = get_jwt_identity()
         # the old PW hash is stored in the reset JWT to check if the token has
         # been used already
@@ -231,7 +231,7 @@ class UserResetPasswordResource(ProtectedResource):
         if auth_provider is None:
             abort(405)
         username = get_jwt_identity()
-        claims = get_jwt_claims()
+        claims = get_jwt()
         # the old PW hash is stored in the reset JWT to check if the token has
         # been used already
         if claims["old_hash"] != auth_provider.get_pwhash(username):

--- a/gramps_webapi/api/resources/util.py
+++ b/gramps_webapi/api/resources/util.py
@@ -110,9 +110,7 @@ def get_sex_profile(person: Person) -> str:
 
 
 def get_event_participants_for_handle(
-    db_handle: DbReadBase,
-    handle: Handle,
-    locale: GrampsLocale = glocale,
+    db_handle: DbReadBase, handle: Handle, locale: GrampsLocale = glocale,
 ) -> Dict:
     """Get event participants given a handle."""
     result = {"people": [], "families": []}
@@ -366,6 +364,7 @@ def get_person_profile_for_object(
     if "all" in args or "age" in args:
         options.append("age")
         if birth_event is not None:
+            print(locale.__dict__)
             birth["age"] = locale.translation.sgettext("0 days")
             if death_event is not None:
                 death["age"] = (
@@ -656,9 +655,7 @@ def get_soundex(
 
 
 def get_reference_profile_for_object(
-    db_handle: DbReadBase,
-    obj: GrampsObject,
-    locale: GrampsLocale = glocale,
+    db_handle: DbReadBase, obj: GrampsObject, locale: GrampsLocale = glocale,
 ) -> Dict:
     """Return reference profiles for an object."""
     profile = {}

--- a/gramps_webapi/api/resources/util.py
+++ b/gramps_webapi/api/resources/util.py
@@ -364,7 +364,9 @@ def get_person_profile_for_object(
     if "all" in args or "age" in args:
         options.append("age")
         if birth_event is not None:
-            birth["age"] = locale.translation.sgettext("0 days")
+            birth["age"] = locale.translation.ngettext(
+                "{number_of} day", "{number_of} days", 0
+            ).format(number_of=0)
             if death_event is not None:
                 death["age"] = (
                     Span(birth_event.date, death_event.date)
@@ -444,7 +446,9 @@ def get_family_profile_for_object(
     )
     if "all" in args or "span" in args:
         if marriage_event is not None:
-            marriage["span"] = locale.translation.sgettext("0 days")
+            marriage["span"] = locale.translation.ngettext(
+                "{number_of} day", "{number_of} days", 0
+            ).format(number_of=0)
             if divorce_event is not None:
                 divorce["span"] = (
                     Span(marriage_event.date, divorce_event.date)

--- a/gramps_webapi/api/resources/util.py
+++ b/gramps_webapi/api/resources/util.py
@@ -364,7 +364,6 @@ def get_person_profile_for_object(
     if "all" in args or "age" in args:
         options.append("age")
         if birth_event is not None:
-            print(locale.__dict__)
             birth["age"] = locale.translation.sgettext("0 days")
             if death_event is not None:
                 death["age"] = (

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ REQUIREMENTS = [
     "Flask-Caching",
     "Flask-Compress",
     "Flask-Cors",
-    "Flask-JWT-Extended",
+    "Flask-JWT-Extended>=4.2.1",
     "Flask-Limiter",
     "webargs",
     "SQLAlchemy",

--- a/tests/test_endpoints/test_families.py
+++ b/tests/test_endpoints/test_families.py
@@ -540,11 +540,11 @@ class TestFamilies(unittest.TestCase):
     def test_get_families_parameter_profile_expected_result_with_locale(self):
         """Test expected profile response for a locale."""
         rv = check_success(
-            self, TEST_URL + "?page=1&keys=profile&profile=all&locale=de"
+            self, TEST_URL + "?page=1&keys=profile&profile=all&locale=it"
         )
-        self.assertEqual(rv[0]["profile"]["father"]["birth"]["age"], "0 Tage")
-        self.assertEqual(rv[0]["profile"]["father"]["birth"]["type"], "Geburt")
-        self.assertEqual(rv[0]["profile"]["relationship"], "Verheiratet")
+        self.assertEqual(rv[0]["profile"]["father"]["birth"]["age"], "0 giorni")
+        self.assertEqual(rv[0]["profile"]["father"]["birth"]["type"], "Nascita")
+        self.assertEqual(rv[0]["profile"]["relationship"], "Sposati")
 
     def test_get_families_parameter_backlinks_validate_semantics(self):
         """Test invalid backlinks parameter and values."""


### PR DESCRIPTION
This should fix #175.

Note an important announcement in the Flask JWT Extended [upgrade guide](https://flask-jwt-extended.readthedocs.io/en/stable/v4_upgrade_guide/):

> This has the unfortunate side effect that any existing JWTs your application is using will not work correctly if they utilize additional claims. We strongly suggest changing your secret key to force all users to get the new format of JWTs. If that is not feasible for your appilication you could build a shim to handle both the old JWTs which store additional claims in the user_claims key, and the new format where additional claims are now stored at the top level, until all the JWTs have had a chance to cycle to the new format.