### PR TITLE
Docker: tag image on release

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - master
+  release:
+    types:
+      - created
+
 
 jobs:
   build:
@@ -24,9 +28,16 @@ jobs:
         run: echo ${{ steps.buildx.outputs.platforms }}
       - name: login to docker hub
         run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
-      - name: build the image
+      - name: tag and push devel image
         run: |
           docker build --push \
+            --tag dmstraub/gramps-webapi:latest-devel \
+            --platform linux/amd64,linux/arm/v7,linux/arm64 .
+      - name: tag and push release image
+        if: github.event_name == 'release'
+        run: |
+          docker build --push \
+            --tag dmstraub/gramps-webapi:${{ github.event.release.tag_name }} \
             --tag dmstraub/gramps-webapi:latest \
             --platform linux/amd64,linux/arm/v7,linux/arm64 .
 


### PR DESCRIPTION
So far, we only pushed the `latest` tag for the Docker Hub image built on every push to `master`. As more people are trying out the Docker-based deployment now, I think it would be good to have several tags. This is implement in this modified workflow:

- `latest-devel` is the image built with the latest `master`
- On Github release, an image tagged with the release name (`v...`) is created
- The `latest` tag now points to the latest *released* version

I would then also create a `v0.1.1` release just for the sake of creating those tags.