### PR TITLE
Implement file upload (fixes #189)

### DIFF
--- a/gramps_webapi/api/__init__.py
+++ b/gramps_webapi/api/__init__.py
@@ -39,6 +39,7 @@ from .resources.exporters import (
 )
 from .resources.facts import FactsResource
 from .resources.families import FamiliesResource, FamilyResource
+from .resources.file import MediaFileResource
 from .resources.filters import FilterResource, FiltersResource, FiltersResources
 from .resources.holidays import HolidayResource, HolidaysResource
 from .resources.living import LivingDatesResource, LivingResource
@@ -218,14 +219,9 @@ register_endpt(
 # Search
 register_endpt(SearchResource, "/search/", "search")
 
-# Media files
-@api_blueprint.route("/media/<string:handle>/file")
-@jwt_required_ifauth
-def download_file(handle):
-    """Download a file."""
-    base_dir = current_app.config.get("MEDIA_BASE_DIR")
-    handler = LocalFileHandler(handle, base_dir)
-    return handler.send_file()
+register_endpt(
+    MediaFileResource, "/media/<string:handle>/file", "media_file",
+)
 
 
 # Thumbnails

--- a/gramps_webapi/api/file.py
+++ b/gramps_webapi/api/file.py
@@ -144,6 +144,7 @@ def upload_file(base_dir, stream: BinaryIO, checksum: str, mime: str) -> str:
     base_dir = base_dir or get_media_base_dir()
     if not mime:
         raise ValueError("Missing MIME type")
+    mimetypes.init()
     ext = mimetypes.guess_extension(mime, strict=False)
     if not ext:
         raise ValueError("MIME type not recognized")

--- a/gramps_webapi/api/file.py
+++ b/gramps_webapi/api/file.py
@@ -144,7 +144,7 @@ def upload_file(base_dir, stream: BinaryIO, checksum: str, mime: str) -> str:
     base_dir = base_dir or get_media_base_dir()
     if not mime:
         raise ValueError("Missing MIME type")
-    ext = mimetypes.guess_extension(mime)
+    ext = mimetypes.guess_extension(mime, strict=False)
     if not ext:
         raise ValueError("MIME type not recognized")
     filename = f"{checksum}{ext}"

--- a/gramps_webapi/api/file.py
+++ b/gramps_webapi/api/file.py
@@ -20,7 +20,6 @@
 """File handling utilities."""
 
 import hashlib
-import mimetypes
 import os
 from io import BytesIO
 from pathlib import Path
@@ -29,10 +28,10 @@ from typing import Any, BinaryIO, Optional, Tuple, Union
 from flask import abort, send_file, send_from_directory
 from gramps.gen.errors import HandleError
 from gramps.gen.lib import Media
-from gramps.gen.utils.file import create_checksum
 from werkzeug.datastructures import FileStorage
 
 from gramps_webapi.const import MIME_JPEG
+from gramps_webapi.util import get_extension
 
 from .image import ThumbnailHandler
 from .util import get_db_handle, get_media_base_dir
@@ -144,8 +143,7 @@ def upload_file(base_dir, stream: BinaryIO, checksum: str, mime: str) -> str:
     base_dir = base_dir or get_media_base_dir()
     if not mime:
         raise ValueError("Missing MIME type")
-    mimetypes.init()
-    ext = mimetypes.guess_extension(mime, strict=False)
+    ext = get_extension(mime)
     if not ext:
         raise ValueError("MIME type not recognized")
     filename = f"{checksum}{ext}"

--- a/gramps_webapi/api/file.py
+++ b/gramps_webapi/api/file.py
@@ -141,6 +141,7 @@ class LocalFileHandler(FileHandler):
 
 def upload_file(base_dir, stream: BinaryIO, checksum: str, mime: str) -> str:
     """Upload a file from a stream, returning the file path."""
+    base_dir = base_dir or get_media_base_dir()
     if not mime:
         raise ValueError("Missing MIME type")
     ext = mimetypes.guess_extension(mime)

--- a/gramps_webapi/api/resources/file.py
+++ b/gramps_webapi/api/resources/file.py
@@ -1,0 +1,49 @@
+"""Endpoint for up- and downloading media files."""
+
+from http import HTTPStatus
+
+from flask import Response, abort, current_app, request
+from gramps.gen.db import DbTxn
+from gramps.gen.errors import HandleError
+
+from ...auth.const import PERM_EDIT_OBJ
+from ..auth import require_permissions
+from ..file import LocalFileHandler, process_file, upload_file
+from ..util import get_db_handle
+from . import ProtectedResource
+from .util import update_object
+
+
+class MediaFileResource(ProtectedResource):
+    """Resource for media files."""
+
+    def get(self, handle) -> Response:
+        """Download a file."""
+        base_dir = current_app.config.get("MEDIA_BASE_DIR")
+        handler = LocalFileHandler(handle, base_dir)
+        return handler.send_file()
+
+    def put(self, handle) -> Response:
+        """Upload a file and update the media object."""
+        require_permissions([PERM_EDIT_OBJ])
+        db_handle = get_db_handle()
+        try:
+            obj = db_handle.get_media_from_handle()
+        except HandleError:
+            abort(HTTPStatus.NOT_FOUND)
+        checksum, f = process_file(request.stream)
+        base_dir = current_app.config.get("MEDIA_BASE_DIR")
+        mime = request.content_type
+        if not mime:
+            abort(HTTPStatus.NOT_ACCEPTABLE)
+        path = upload_file(base_dir, f, checksum, mime)
+        obj.set_checksum(checksum)
+        obj.set_path(path)
+        obj.set_mime_type(mime)
+        db_handle_writable = get_db_handle(readonly=False)
+        with DbTxn("Update media object", db_handle_writable) as trans:
+            try:
+                update_object(db_handle_writable, obj, trans)
+            except ValueError:
+                abort(400)
+        return Response(status=200)

--- a/gramps_webapi/api/resources/file.py
+++ b/gramps_webapi/api/resources/file.py
@@ -1,3 +1,23 @@
+#
+# Gramps Web API - A RESTful API for the Gramps genealogy program
+#
+# Copyright (C) 2020        Christopher Horn
+# Copyright (C) 2020, 2021  David Straub
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
 """Endpoint for up- and downloading media files."""
 
 import json

--- a/gramps_webapi/api/resources/file.py
+++ b/gramps_webapi/api/resources/file.py
@@ -41,7 +41,6 @@ class MediaFileResource(ProtectedResource):
             abort(HTTPStatus.CONFLICT)
         base_dir = current_app.config.get("MEDIA_BASE_DIR")
         path = upload_file(base_dir, f, checksum, mime)
-        print("path", path)
         obj.set_checksum(checksum)
         obj.set_path(path)
         obj.set_mime_type(mime)

--- a/gramps_webapi/api/resources/media.py
+++ b/gramps_webapi/api/resources/media.py
@@ -20,18 +20,25 @@
 
 """Media API resource."""
 
+import uuid
+from http import HTTPStatus
 from typing import Dict
 
+from flask import Response, abort, current_app, request
 from gramps.gen.const import GRAMPS_LOCALE as glocale
+from gramps.gen.db import DbTxn
 from gramps.gen.lib import Media
 from gramps.gen.utils.grampslocale import GrampsLocale
 
+from ...auth.const import PERM_ADD_OBJ
+from ..auth import require_permissions
+from ..file import upload_file, process_file
 from .base import (
     GrampsObjectProtectedResource,
     GrampsObjectResourceHelper,
     GrampsObjectsProtectedResource,
 )
-from .util import get_extended_attributes, get_media_profile_for_object
+from .util import add_object, get_extended_attributes, get_media_profile_for_object
 
 
 class MediaObjectResourceHelper(GrampsObjectResourceHelper):
@@ -58,3 +65,24 @@ class MediaObjectResource(GrampsObjectProtectedResource, MediaObjectResourceHelp
 
 class MediaObjectsResource(GrampsObjectsProtectedResource, MediaObjectResourceHelper):
     """Media objects resource."""
+
+    def post(self) -> Response:
+        """Post a new object."""
+        require_permissions([PERM_ADD_OBJ])
+        mime = request.content_type
+        if not mime:
+            abort(HTTPStatus.NOT_ACCEPTABLE)
+        checksum, f = process_file(request.stream)
+        base_dir = current_app.config.get("MEDIA_BASE_DIR")
+        path = upload_file(base_dir, f, checksum, mime)
+        db_handle = self.db_handle_writable
+        obj = Media()
+        obj.set_checksum(checksum)
+        obj.set_path(path)
+        obj.set_mime_type(mime)
+        with DbTxn("Add object", db_handle) as trans:
+            try:
+                add_object(db_handle, obj, trans)
+            except ValueError:
+                abort(400)
+        return Response(status=201)

--- a/gramps_webapi/api/resources/media.py
+++ b/gramps_webapi/api/resources/media.py
@@ -38,7 +38,12 @@ from .base import (
     GrampsObjectResourceHelper,
     GrampsObjectsProtectedResource,
 )
-from .util import add_object, get_extended_attributes, get_media_profile_for_object
+from .util import (
+    add_object,
+    get_extended_attributes,
+    get_media_profile_for_object,
+    transaction_to_json,
+)
 
 
 class MediaObjectResourceHelper(GrampsObjectResourceHelper):
@@ -85,4 +90,5 @@ class MediaObjectsResource(GrampsObjectsProtectedResource, MediaObjectResourceHe
                 add_object(db_handle, obj, trans)
             except ValueError:
                 abort(400)
-        return Response(status=201)
+            trans_dict = transaction_to_json(trans)
+        return self.response(201, trans_dict, total_items=len(trans_dict))

--- a/gramps_webapi/api/resources/util.py
+++ b/gramps_webapi/api/resources/util.py
@@ -804,8 +804,6 @@ def update_object(
     obj_class = obj.__class__.__name__.lower()
     if not has_handle(db_handle, obj):
         raise ValueError("Cannot be used for new objects.")
-    if has_gramps_id(db_handle, obj):
-        raise ValueError("Gramps ID already exists.")
     try:
         commit_method = db_handle.method("commit_%s", obj_class)
         return commit_method(obj, trans)

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -3151,21 +3151,17 @@ paths:
     post:
       tags:
       - media
-      summary: "Add a new media object to the database."
+      summary: "Add a new media file to the database."
       operationId: createMedia
       security:
         - Bearer: []
-      consumes:
-        - application/json
-      parameters:
-        - in: body
-          name: media
-          description: The media object to add
-          schema:
-            $ref: "#/definitions/Media"
       responses:
         201:
           description: Created
+          schema:
+            type: array
+            items:
+              $ref: "#/definitions/Transaction"
         400:
           description: "Bad Request: Malformed request could not be parsed."
         401:
@@ -3303,6 +3299,13 @@ paths:
 
 
   /media/{handle}/file:
+    parameters:
+    - name: handle
+      in: path
+      required: true
+      type: string
+      minLength: 8
+      description: "The unique identifier for a media item."
     get:
       tags:
       - media
@@ -3310,13 +3313,6 @@ paths:
       operationId: getMediaItemFile
       security:
         - Bearer: []
-      parameters:
-      - name: handle
-        in: path
-        required: true
-        type: string
-        minLength: 8
-        description: "The unique identifier for a media item."
       responses:
         200:
           description: "OK: Successful operation."
@@ -3326,6 +3322,26 @@ paths:
           description: "Unauthorized: Missing authorization header."
         404:
           description: "Not Found: Media item not found."
+    put:
+      tags:
+      - media
+      summary: "Update an existing media object's file."
+      operationId: updateFile
+      security:
+        - Bearer: []
+      responses:
+        200:
+          description: "OK. Successful operation."
+          schema:
+            type: array
+            items:
+              $ref: "#/definitions/Transaction"
+        400:
+          description: "Bad Request: Malformed request could not be parsed."
+        401:
+          description: "Unauthorized: Missing authorization header."
+        422:
+          description: "Unprocessable Entity: Invalid or bad parameter provided."
 
 
   /media/{handle}/thumbnail/{size}:

--- a/gramps_webapi/util/__init__.py
+++ b/gramps_webapi/util/__init__.py
@@ -18,3 +18,28 @@
 #
 
 """Utility functions."""
+
+import mimetypes
+from typing import Optional
+
+from ..const import MIME_TYPES
+
+
+def get_extension(mime: str) -> Optional[str]:
+    """Get extension from MIME type."""
+    # try hard-coded types first
+    for ext, ext_mime in MIME_TYPES.items():
+        if mime == ext_mime:
+            return ext
+    # last resort
+    return mimetypes.guess_extension(mime, strict=False)
+
+
+def get_type(ext: str) -> Optional[str]:
+    """Get file extension from MIME type."""
+    # try hard-coded types first
+    if ext in MIME_TYPES:
+        return MIME_TYPES[ext]
+    # last resort
+    typ, enc = mimetypes.guess_type(ext, strict=False)
+    return typ

--- a/tests/test_endpoints/test_post.py
+++ b/tests/test_endpoints/test_post.py
@@ -291,23 +291,3 @@ class TestObjectCreation(unittest.TestCase):
         self.assertEqual(rv.status_code, 200)
         obj_dict = rv.json
         self.assertEqual(obj_dict["name"], obj["name"])
-
-    def test_add_media(self):
-        """Add a single media."""
-        handle = make_handle()
-        obj = {"handle": handle, "desc": "My photo"}
-        headers = get_headers(self.client, "admin", "123")
-        rv = self.client.post("/api/media/", json=obj, headers=headers)
-        self.assertEqual(rv.status_code, 201)
-        rv = self.client.get(f"/api/media/{handle}", headers=headers)
-        self.assertEqual(rv.status_code, 200)
-        obj_dict = rv.json
-        self.assertEqual(obj_dict["desc"], obj["desc"])
-        handle = make_handle()
-        tag_handle = make_handle()
-        tag_obj = {"handle": tag_handle, "name": "MyTag"}
-        rv = self.client.post("/api/tags/", json=tag_obj, headers=headers)
-        obj = {"handle": handle, "desc": "My photo", "tag_list": [tag_handle]}
-        rv = self.client.post("/api/media/", json=obj, headers=headers)
-        self.assertEqual(rv.status_code, 201)
-

--- a/tests/test_endpoints/test_upload.py
+++ b/tests/test_endpoints/test_upload.py
@@ -1,0 +1,102 @@
+#
+# Gramps Web API - A RESTful API for the Gramps genealogy program
+#
+# Copyright (C) 2020      David Straub
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+"""Tests uploading media files POST."""
+
+import hashlib
+import random
+import shutil
+import tempfile
+import unittest
+from io import BytesIO
+from typing import Dict
+from unittest.mock import patch
+
+from gramps.cli.clidbman import CLIDbManager
+from gramps.gen.dbstate import DbState
+from PIL import Image
+
+from gramps_webapi.app import create_app
+from gramps_webapi.auth.const import ROLE_GUEST, ROLE_OWNER
+from gramps_webapi.const import ENV_CONFIG_FILE, TEST_AUTH_CONFIG
+
+
+def get_headers(client, user: str, password: str) -> Dict[str, str]:
+    """Get the auth headers for a specific user."""
+    rv = client.post("/api/token/", json={"username": user, "password": password})
+    access_token = rv.json["access_token"]
+    return {"Authorization": "Bearer {}".format(access_token)}
+
+
+def get_image(color):
+    """Get a JPEG image."""
+    image_file = BytesIO()
+    image = Image.new("RGBA", size=(50, 50), color=color)
+    image.save(image_file, "png")
+    image_file.seek(0)
+    return image_file
+
+
+class TestUpload(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.name = "Test Web API"
+        cls.dbman = CLIDbManager(DbState())
+        cls.dbman.create_new_db_cli(cls.name, dbid="sqlite")
+        with patch.dict("os.environ", {ENV_CONFIG_FILE: TEST_AUTH_CONFIG}):
+            cls.app = create_app()
+        cls.app.config["TESTING"] = True
+        cls.media_base_dir = tempfile.mkdtemp()
+        cls.app.config["MEDIA_BASE_DIR"] = cls.media_base_dir
+        cls.client = cls.app.test_client()
+        sqlauth = cls.app.config["AUTH_PROVIDER"]
+        sqlauth.create_table()
+        sqlauth.add_user(name="user", password="123", role=ROLE_GUEST)
+        sqlauth.add_user(name="admin", password="123", role=ROLE_OWNER)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.dbman.remove_database(cls.name)
+        shutil.rmtree(cls.media_base_dir)
+
+    def test_upload_new_media(self):
+        """Add new media object."""
+        img = get_image(0)
+        img.seek(0)
+        checksum = hashlib.md5(img.getbuffer()).hexdigest()
+        img.seek(0)
+        # try as guest - not allowed
+        headers = get_headers(self.client, "user", "123")
+        rv = self.client.post(
+            "/api/media/", data=None, headers=headers, content_type="image/jpeg"
+        )
+        self.assertEqual(rv.status_code, 403)
+        # try as admin
+        headers = get_headers(self.client, "admin", "123")
+        rv = self.client.post(
+            "/api/media/", data=img.read(), headers=headers, content_type="image/jpeg"
+        )
+        self.assertEqual(rv.status_code, 201)
+        # get the object
+        rv = self.client.get("/api/media/", headers=headers)
+        self.assertEqual(rv.status_code, 200)
+        res = rv.json[0]
+        self.assertEqual(res["path"], f"{res['checksum']}.jpg")
+        self.assertEqual(res["mime"], "image/jpeg")
+        self.assertEqual(res["checksum"], checksum)

--- a/tests/test_endpoints/test_upload.py
+++ b/tests/test_endpoints/test_upload.py
@@ -93,10 +93,16 @@ class TestUpload(unittest.TestCase):
             "/api/media/", data=img.read(), headers=headers, content_type="image/jpeg"
         )
         self.assertEqual(rv.status_code, 201)
+        # check output
+        out = rv.json
+        self.assertEqual(len(out), 1)
+        handle = out[0]["new"]["handle"]
+        self.assertEqual(out[0]["old"], None)
+        self.assertEqual(out[0]["type"], "add")
         # get the object
-        rv = self.client.get("/api/media/", headers=headers)
+        rv = self.client.get(f"/api/media/{handle}", headers=headers)
         self.assertEqual(rv.status_code, 200)
-        res = rv.json[0]
+        res = rv.json
         self.assertEqual(res["path"], f"{res['checksum']}.jpg")
         self.assertEqual(res["mime"], "image/jpeg")
         self.assertEqual(res["checksum"], checksum)


### PR DESCRIPTION
API:

- `POST` of a binary stream to `/api/media/` creates a new, empty media object, stores the file in the media base directory as `<checksum>.<ext>` where `ext` is derived from the MIME type, and returns a transaction JSON (which contains, for instance, the handle of the newly created object). Note: it is no longer possible to `POST` a JSON to the media endpoint as that would create a media object without file!
- `PUT` of a JSON to `/api/media/<handle>` updates the media object (but not its file!)
- `PUT` of a binary stream to `/api/media/<handle>/file` uploads a new file and updates the `path`, `mime`, and `checksum` of the media object accordingly

This means all files uploaded via the web API will be stored as `$MEDIA_BASE_DIRECTORY/<checksum>.<ext>` and the user cannot influence the file name or location. I believe this is necessary as it solves the problems mentioned in #189. It also allows for deduplication as the files are always stored under their MD5 checksum.

The only possible issue I see is that there is no check whether the MIME type supplied by the user is correct or not. However I believe this is acceptable - we cannot really guard against malicious or corrupted files uploaded by authorized users. We do have to make sure that *unauthorized* users cannot access any private information, and I believe this is ensured by this implementation.

Docs still missing.

Edit: note this is rebased on top of #196, so the diff is not useful.