### PR TITLE
Add transactions endpoint

### DIFF
--- a/gramps_webapi/api/__init__.py
+++ b/gramps_webapi/api/__init__.py
@@ -80,6 +80,7 @@ from .resources.user import (
     UserTriggerResetPasswordResource,
 )
 from .resources.objects import CreateObjectsResource
+from .resources.transactions import TransactionsResource
 from .util import make_cache_key_thumbnails, use_args
 
 api_blueprint = Blueprint("api", __name__, url_prefix=API_PREFIX)
@@ -93,6 +94,8 @@ def register_endpt(resource: Type[Resource], url: str, name: str):
 
 # Objects
 register_endpt(CreateObjectsResource, "/objects/", "objects")
+# Transactions
+register_endpt(TransactionsResource, "/transactions/", "transactions")
 # Token
 register_endpt(TokenResource, "/token/", "token")
 register_endpt(TokenRefreshResource, "/token/refresh/", "token_refresh")

--- a/gramps_webapi/api/resources/transactions.py
+++ b/gramps_webapi/api/resources/transactions.py
@@ -1,0 +1,111 @@
+#
+# Gramps Web API - A RESTful API for the Gramps genealogy program
+#
+# Copyright (C) 2021      David Straub
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+"""Raw database transaction API resource."""
+
+import json
+from typing import Dict
+
+from flask import Response, abort, request
+from gramps.gen.db import DbTxn
+from gramps.gen.db.base import DbReadBase
+from gramps.gen.db.dbconst import CLASS_TO_KEY_MAP, TXNADD, TXNDEL, TXNUPD
+from gramps.gen.errors import HandleError
+from gramps.gen.lib.serialize import from_json, to_json
+from gramps.gen.merge.diff import diff_items
+
+from ...auth.const import PERM_ADD_OBJ, PERM_DEL_OBJ, PERM_EDIT_OBJ
+from ..auth import require_permissions
+from ..util import get_db_handle
+from . import ProtectedResource
+from .util import transaction_to_json
+
+trans_code = {"delete": TXNDEL, "add": TXNADD, "update": TXNUPD}
+
+
+class TransactionsResource(ProtectedResource):
+    """Resource for raw database transactions."""
+
+    def post(self) -> Response:
+        """Post the transaction."""
+        require_permissions([PERM_ADD_OBJ, PERM_EDIT_OBJ, PERM_DEL_OBJ])
+        payload = request.json
+        if not payload:
+            abort(400)  # disallow empty payload
+        db_handle = get_db_handle(readonly=False)
+        with DbTxn("Raw transaction", db_handle) as trans:
+            for item in payload:
+                try:
+                    class_name = item["_class"]
+                    trans_type = item["type"]
+                    handle = item["handle"]
+                    old_data = item["old"]
+                    if not self.old_unchanged(db_handle, class_name, handle, old_data):
+                        abort(409)  # object has changed!
+                    new_data = item["new"]
+                    if new_data:
+                        new_obj = from_json(json.dumps(new_data))
+                    if trans_type == "delete":
+                        self.handle_delete(trans, class_name, handle)
+                    elif trans_type == "add":
+                        self.handle_add(trans, class_name, new_obj)
+                    elif trans_type == "update":
+                        self.handle_commit(trans, class_name, new_obj)
+                    else:
+                        abort(400)  # unexpected type
+                except (KeyError, UnicodeDecodeError, json.JSONDecodeError, TypeError):
+                    abort(400)
+            trans_dict = transaction_to_json(trans)
+        res = Response(
+            response=json.dumps(trans_dict), status=200, mimetype="application/json",
+        )
+        res.headers.add("X-Total-Count", len(trans_dict))
+        return res
+
+    def handle_delete(self, trans: DbTxn, class_name: str, handle: str) -> None:
+        """Handle a delete action."""
+        del_func = trans.db.method("remove_%s", class_name)
+        del_func(handle, trans)
+
+    def handle_commit(self, trans: DbTxn, class_name: str, obj) -> None:
+        """Handle an update action."""
+        com_func = trans.db.method("commit_%s", class_name)
+        com_func(obj, trans)
+
+    def handle_add(self, trans: DbTxn, class_name: str, obj) -> None:
+        """Handle an add action."""
+        if class_name != "Tag" and not obj.gramps_id:
+            abort(400)  # gramps ID missing!
+        self.handle_commit(trans, class_name, obj)
+
+    def old_unchanged(
+        self, db: DbReadBase, class_name: str, handle: str, old_data: Dict
+    ) -> bool:
+        """Check if the "old" object is still unchanged."""
+        handle_func = db.method("get_%s_from_handle", class_name)
+        try:
+            obj = handle_func(handle)
+        except HandleError:
+            if old_data is None:
+                return True
+            return False
+        obj_dict = json.loads(to_json(obj))
+        if diff_items(class_name, old_data, obj_dict):
+            return False
+        return True

--- a/gramps_webapi/api/resources/util.py
+++ b/gramps_webapi/api/resources/util.py
@@ -779,7 +779,7 @@ def validate_object_dict(obj_dict: Dict[str, Any]) -> bool:
     """Validate a dict representation of a Gramps object vs. its schema."""
     try:
         obj_cls = getattr(gramps.gen.lib, obj_dict["_class"])
-    except (KeyError, AttributeError):
+    except (KeyError, AttributeError, TypeError):
         return False
     schema = obj_cls.get_schema()
     try:

--- a/gramps_webapi/api/resources/util.py
+++ b/gramps_webapi/api/resources/util.py
@@ -819,7 +819,7 @@ def update_object(
 def transaction_to_json(transaction: DbTxn) -> List[Dict[str, Any]]:
     """Return a JSON representation of a database transaction."""
     out = []
-    for recno in transaction.get_recnos(reverse=True):
+    for recno in transaction.get_recnos(reverse=False):
         key, action, handle, old_data, new_data = transaction.get_record(recno)
         try:
             obj_cls_name = KEY_TO_CLASS_MAP[key]

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -46,6 +46,10 @@ tags:
   description: Work with notes.
 - name: tags
   description: Work with tags.
+- name: objects
+  description: Work with primary objects.
+- name: transactions
+  description: Work with raw database transactions.
 - name: types
   description: Work with default and custom types.
 - name: name-formats
@@ -4032,6 +4036,46 @@ paths:
         422:
           description: "Unprocessable Entity: Invalid or bad parameter provided."
 
+
+##############################################################################
+# Endpoint - Transactions
+##############################################################################
+
+  /transactions:
+    post:
+      tags:
+      - transactions
+      summary: "Commit a raw database transaction."
+      operationId: newTransaction
+      security:
+        - Bearer: []
+      consumes:
+        - application/json
+      parameters:
+        - in: body
+          name: source
+          description: The database transaction
+          schema:
+            type: array
+            items:
+              $ref: "#/definitions/Transaction"
+      responses:
+        200:
+          description: "OK: Successful operation."
+          schema:
+            type: array
+            items:
+              $ref: "#/definitions/Transaction"
+        400:
+          description: "Bad Request: Malformed request could not be parsed."
+        401:
+          description: "Unauthorized: Missing authorization header."
+        403:
+          description: "Unauthorized: Insufficient permissions."
+        409:
+          description: "Conflict: Objects have changed."
+        422:
+          description: "Unprocessable Entity: Invalid or bad parameter provided."
 
 
 ##############################################################################

--- a/tests/test_endpoints/test_transactions.py
+++ b/tests/test_endpoints/test_transactions.py
@@ -248,3 +248,33 @@ class TestTransactionResource(unittest.TestCase):
         self.assertEqual(rv.status_code, 404)
         rv = self.client.get(f"/api/notes/{handle2}", headers=headers)
         self.assertEqual(rv.status_code, 404)
+
+    def test_missing_handle(self):
+        """Add with missing handle."""
+        handle = make_handle()
+        obj = {
+            "_class": "Note",
+            "text": {"_class": "StyledText", "string": "My first note."},
+            "gramps_id": "N31",
+        }
+        trans = [{"type": "add", "_class": "Note", "old": None, "new": obj}]
+        headers = get_headers(self.client, "editor", "123")
+        # add
+        rv = self.client.post("/api/transactions/", json=trans, headers=headers)
+        self.assertEqual(rv.status_code, 400)
+
+    def test_missing_gramps_id(self):
+        """Add with missing gramps ID."""
+        handle = make_handle()
+        obj = {
+            "_class": "Note",
+            "text": {"_class": "StyledText", "string": "My first note."},
+            "handle": handle,
+        }
+        trans = [
+            {"type": "add", "_class": "Note", "handle": handle, "old": None, "new": obj}
+        ]
+        headers = get_headers(self.client, "editor", "123")
+        # add
+        rv = self.client.post("/api/transactions/", json=trans, headers=headers)
+        self.assertEqual(rv.status_code, 400)

--- a/tests/test_endpoints/test_transactions.py
+++ b/tests/test_endpoints/test_transactions.py
@@ -1,0 +1,139 @@
+#
+# Gramps Web API - A RESTful API for the Gramps genealogy program
+#
+# Copyright (C) 2020      David Straub
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+"""Tests transaction endpoint."""
+
+import unittest
+import uuid
+from copy import deepcopy
+from typing import Dict
+from unittest.mock import patch
+
+from gramps.cli.clidbman import CLIDbManager
+from gramps.gen.dbstate import DbState
+
+from gramps_webapi.app import create_app
+from gramps_webapi.auth.const import (
+    ROLE_CONTRIBUTOR,
+    ROLE_EDITOR,
+    ROLE_GUEST,
+    ROLE_MEMBER,
+    ROLE_OWNER,
+)
+from gramps_webapi.const import ENV_CONFIG_FILE, TEST_AUTH_CONFIG
+
+
+def get_headers(client, user: str, password: str) -> Dict[str, str]:
+    """Get the auth headers for a specific user."""
+    rv = client.post("/api/token/", json={"username": user, "password": password})
+    access_token = rv.json["access_token"]
+    return {"Authorization": "Bearer {}".format(access_token)}
+
+
+def make_handle() -> str:
+    """Make a new valid handle."""
+    return str(uuid.uuid4())
+
+
+class TestTransactionResource(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.name = "Test Web API"
+        cls.dbman = CLIDbManager(DbState())
+        cls.dbman.create_new_db_cli(cls.name, dbid="sqlite")
+        with patch.dict("os.environ", {ENV_CONFIG_FILE: TEST_AUTH_CONFIG}):
+            cls.app = create_app()
+        cls.app.config["TESTING"] = True
+        cls.client = cls.app.test_client()
+        sqlauth = cls.app.config["AUTH_PROVIDER"]
+        sqlauth.create_table()
+        sqlauth.add_user(name="user", password="123", role=ROLE_GUEST)
+        sqlauth.add_user(name="admin", password="123", role=ROLE_OWNER)
+        sqlauth.add_user(name="member", password="123", role=ROLE_MEMBER)
+        sqlauth.add_user(name="editor", password="123", role=ROLE_EDITOR)
+        sqlauth.add_user(name="contributor", password="123", role=ROLE_CONTRIBUTOR)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.dbman.remove_database(cls.name)
+
+    def test_transaction_add_update_delete(self):
+        """Add, update, and delete a single note."""
+        handle = make_handle()
+        obj = {
+            "_class": "Note",
+            "handle": handle,
+            "text": {"_class": "StyledText", "string": "My first note."},
+            "gramps_id": "N1",
+        }
+        trans = [
+            {"type": "add", "_class": "Note", "handle": handle, "old": None, "new": obj}
+        ]
+        for username in ["user", "member", "contributor"]:
+            # these three roles should not be able to post a transaction!
+            headers = get_headers(self.client, username, "123")
+            rv = self.client.post("/api/transactions/", json=obj, headers=headers)
+            self.assertEqual(rv.status_code, 403)
+        headers = get_headers(self.client, "editor", "123")
+        # add
+        rv = self.client.post("/api/transactions/", json=trans, headers=headers)
+        self.assertEqual(rv.status_code, 200)
+        trans_dict = rv.json
+        self.assertEqual(len(trans_dict), 1)
+        self.assertEqual(trans_dict[0]["handle"], handle)
+        self.assertEqual(trans_dict[0]["type"], "add")
+        self.assertEqual(trans_dict[0]["_class"], "Note")
+        rv = self.client.get(f"/api/notes/{handle}", headers=headers)
+        self.assertEqual(rv.status_code, 200)
+        obj_dict = rv.json
+        self.assertEqual(obj_dict["handle"], handle)
+        self.assertEqual(obj_dict["text"]["string"], "My first note.")
+        # update
+        obj_new = deepcopy(obj)
+        obj_new["gramps_id"] = "N2"
+        trans = [
+            {
+                "type": "update",
+                "_class": "Note",
+                "handle": handle,
+                "old": obj,
+                "new": obj_new,
+            }
+        ]
+        rv = self.client.post("/api/transactions/", json=trans, headers=headers)
+        self.assertEqual(rv.status_code, 200)
+        rv = self.client.get(f"/api/notes/{handle}", headers=headers)
+        self.assertEqual(rv.status_code, 200)
+        obj_dict = rv.json
+        self.assertEqual(obj_dict["handle"], handle)
+        self.assertEqual(obj_dict["gramps_id"], "N2")
+        # delete
+        trans = [
+            {
+                "type": "delete",
+                "_class": "Note",
+                "handle": handle,
+                "old": obj_new,
+                "new": None,
+            }
+        ]
+        rv = self.client.post("/api/transactions/", json=trans, headers=headers)
+        self.assertEqual(rv.status_code, 200)
+        rv = self.client.get(f"/api/notes/{handle}", headers=headers)
+        self.assertEqual(rv.status_code, 404)


### PR DESCRIPTION
This PR adds a new `/transactions/` endpoint for `POST` which allows to post a raw database transaction, of the same form that is returned in the response of the existing `POST`/`PUT`/`DELETE` requests.

There are two main applications for this endpoint:

1. To undo a transaction - e.g. an application can take the response from a `DELETE`, switch `delete` with `add` and `old` with `new` - and post it back to `/transactions/` to undo the delete. We could even make this simpler in the future by adding a `reverse` query parameter that does this reversion in the backend automatically.
2. For the synchronization addon (#163). In https://github.com/DavidMStraub/gramps-addon-webapisync, I am almost finished except for the part where I have to push the changes back to the API. With this new endpoint, this is very simple: during sync, I collect all the changes in a transaction on an in-memory DB, then finally I post the JSONized transaction to the new endpoint.
