### PR TITLE
Implement user registration (fixes #203)

### DIFF
--- a/gramps_webapi/api/__init__.py
+++ b/gramps_webapi/api/__init__.py
@@ -74,6 +74,7 @@ from .resources.types import (
 )
 from .resources.user import (
     UserChangePasswordResource,
+    UserConfirmEmailResource,
     UserRegisterResource,
     UserResetPasswordResource,
     UserResource,
@@ -206,6 +207,9 @@ register_endpt(
 )
 register_endpt(
     UserRegisterResource, "/users/<string:user_name>/register/", "register",
+)
+register_endpt(
+    UserConfirmEmailResource, "/users/-/email/confirm/", "confirm_email",
 )
 register_endpt(
     UserChangePasswordResource,

--- a/gramps_webapi/api/__init__.py
+++ b/gramps_webapi/api/__init__.py
@@ -74,6 +74,7 @@ from .resources.types import (
 )
 from .resources.user import (
     UserChangePasswordResource,
+    UserRegisterResource,
     UserResetPasswordResource,
     UserResource,
     UsersResource,
@@ -202,6 +203,9 @@ register_endpt(
 )
 register_endpt(
     UserResource, "/users/<string:user_name>/", "user",
+)
+register_endpt(
+    UserRegisterResource, "/users/<string:user_name>/register/", "register",
 )
 register_endpt(
     UserChangePasswordResource,

--- a/gramps_webapi/api/emails.py
+++ b/gramps_webapi/api/emails.py
@@ -50,3 +50,18 @@ def email_confirm_email(base_url: str, token: str):
 {base_url}/api/users/-/email/confirm/?jwt={token}
 """
 
+
+def email_new_user(base_url: str, username: str, fullname: str, email: str):
+    """E-mail notifying owners of a new registered user."""
+    intro = _("A new user registered at %s:") % base_url
+    label_username = _("User name")
+    label_fullname = _("Full name")
+    label_email = _("E-mail")
+    user_details = f"""{label_username}: {username}
+{label_fullname}: {fullname}
+{label_email}: {email}
+"""
+    return f"""{intro}
+
+{user_details}
+"""

--- a/gramps_webapi/api/emails.py
+++ b/gramps_webapi/api/emails.py
@@ -1,3 +1,22 @@
+#
+# Gramps Web API - A RESTful API for the Gramps genealogy program
+#
+# Copyright (C) 2021      David Straub
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+
 """Texts for e-mails."""
 
 from gettext import gettext as _

--- a/gramps_webapi/api/emails.py
+++ b/gramps_webapi/api/emails.py
@@ -1,0 +1,52 @@
+"""Texts for e-mails."""
+
+from gettext import gettext as _
+
+
+def email_reset_pw(base_url: str, token: str):
+    """Reset password e-mail text."""
+    intro = _(
+        "You are receiving this e-mail because you (or someone else) "
+        "have requested the reset of the password for your account."
+    )
+
+    action = _(
+        "Please click on the following link, or paste this into your browser "
+        "to complete the process:"
+    )
+
+    end = _(
+        "If you did not request this, please ignore this e-mail "
+        "and your password will remain unchanged."
+    )
+    return f"""{intro}
+
+{action}
+
+{base_url}/api/users/-/password/reset/?jwt={token}
+
+{end}
+"""
+
+
+def email_confirm_email(base_url: str, token: str):
+    """Confirm e-mail address e-mail text."""
+    intro = (
+        _(
+            "You are receiving this e-mail because you (or someone else) "
+            "have registered a new account at %s."
+        )
+        % base_url
+    )
+    action = _(
+        "Please click on the following link, or paste this into your browser "
+        "to complete the process:"
+    )
+
+    return f"""{intro}
+
+{action}
+
+{base_url}/api/users/-/email/confirm/?jwt={token}
+"""
+

--- a/gramps_webapi/api/resources/__init__.py
+++ b/gramps_webapi/api/resources/__init__.py
@@ -21,7 +21,11 @@
 
 from flask.views import MethodView
 
-from ..auth import jwt_refresh_token_required_ifauth, jwt_required_ifauth
+from ..auth import (
+    jwt_limited_scope_required_ifauth,
+    jwt_refresh_token_required_ifauth,
+    jwt_required_ifauth,
+)
 
 
 class Resource(MethodView):
@@ -38,3 +42,9 @@ class RefreshProtectedResource(Resource):
     """Resource requiring a JWT refresh token."""
 
     decorators = [jwt_refresh_token_required_ifauth]
+
+
+class LimitedScopeProtectedResource(Resource):
+    """Resource requiring JWT authentication with limited scope."""
+
+    decorators = [jwt_limited_scope_required_ifauth]

--- a/gramps_webapi/api/resources/user.py
+++ b/gramps_webapi/api/resources/user.py
@@ -20,6 +20,7 @@
 """User administration resources."""
 
 import datetime
+from gettext import gettext as _
 
 from flask import abort, current_app, jsonify, render_template
 from flask_jwt_extended import create_access_token, get_jwt, get_jwt_identity
@@ -308,4 +309,6 @@ class UserConfirmEmailResource(LimitedScopeProtectedResource):
                 fullname=current_details.get("full_name", ""),
                 email=claims["email"],
             )
-        return render_template("email_confirmed.html", username=username)
+        title = _("E-mail address confirmation")
+        message = _("Thank you for confirming your e-mail address.")
+        return render_template("confirmation.html", title=title, message=message)

--- a/gramps_webapi/api/resources/user.py
+++ b/gramps_webapi/api/resources/user.py
@@ -39,7 +39,11 @@ from ...auth.const import (
     SCOPE_RESET_PW,
 )
 from ..auth import require_permissions
-from ..tasks import send_email_confirm_email, send_email_reset_password
+from ..tasks import (
+    send_email_confirm_email,
+    send_email_new_user,
+    send_email_reset_password,
+)
 from ..util import use_args
 from . import LimitedScopeProtectedResource, ProtectedResource, Resource
 
@@ -299,4 +303,9 @@ class UserConfirmEmailResource(LimitedScopeProtectedResource):
         if current_details["role"] == ROLE_UNCONFIRMED:
             # otherwise it has been confirmed already
             auth_provider.modify_user(name=username, role=ROLE_DISABLED)
+            send_email_new_user(
+                username=username,
+                fullname=current_details.get("full_name", ""),
+                email=claims["email"],
+            )
         return render_template("email_confirmed.html", username=username)

--- a/gramps_webapi/api/resources/user.py
+++ b/gramps_webapi/api/resources/user.py
@@ -39,7 +39,8 @@ from ...auth.const import (
     SCOPE_RESET_PW,
 )
 from ..auth import require_permissions
-from ..util import send_email, use_args
+from ..tasks import send_email_confirm_email, send_email_reset_password
+from ..util import use_args
 from . import LimitedScopeProtectedResource, ProtectedResource, Resource
 
 limiter = Limiter(key_func=get_remote_address)
@@ -180,18 +181,7 @@ class UserRegisterResource(Resource):
 def handle_reg_conf_email(username: str, email: str, token: str):
     """Handle the e-mail address confirmation token."""
     base_url = current_app.config["BASE_URL"].rstrip("/")
-    send_email(
-        subject="Confirm your e-mail address",
-        body="""You are receiving this e-mail because you (or someone else) have registered a new account at {base_url}.
-
-Please click on the following link, or paste this into your browser to confirm your e-mail address:
-
-{base_url}/api/users/-/email/confirm/?jwt={token}
-""".format(
-            base_url=base_url, token=token
-        ),
-        to=[email],
-    )
+    send_email_confirm_email(base_url=base_url, email=email, token=token)
 
 
 class UserChangePasswordResource(UserChangeBase):
@@ -218,20 +208,7 @@ class UserChangePasswordResource(UserChangeBase):
 def handle_reset_token(username: str, email: str, token: str):
     """Handle the password reset token."""
     base_url = current_app.config["BASE_URL"].rstrip("/")
-    send_email(
-        subject="Reset your Gramps password",
-        body="""You are receiving this e-mail because you (or someone else) have requested the reset of the password for your account.
-
-Please click on the following link, or paste this into your browser to complete the process:
-
-{}/api/users/-/password/reset/?jwt={}
-
-If you did not request this, please ignore this e-mail and your password will remain unchanged.
-""".format(
-            base_url, token
-        ),
-        to=[email],
-    )
+    send_email_reset_password(base_url=base_url, email=email, token=token)
 
 
 class UserTriggerResetPasswordResource(Resource):

--- a/gramps_webapi/api/resources/user.py
+++ b/gramps_webapi/api/resources/user.py
@@ -174,14 +174,8 @@ class UserRegisterResource(Resource):
             # email has to be confirmed within 1h
             expires_delta=datetime.timedelta(hours=1),
         )
-        handle_reg_conf_email(username=user_name, email=args["email"], token=token)
+        send_email_confirm_email(email=args["email"], token=token)
         return "", 201
-
-
-def handle_reg_conf_email(username: str, email: str, token: str):
-    """Handle the e-mail address confirmation token."""
-    base_url = current_app.config["BASE_URL"].rstrip("/")
-    send_email_confirm_email(base_url=base_url, email=email, token=token)
 
 
 class UserChangePasswordResource(UserChangeBase):
@@ -203,12 +197,6 @@ class UserChangePasswordResource(UserChangeBase):
             abort(403)
         auth_provider.modify_user(name=user_name, password=args["new_password"])
         return "", 201
-
-
-def handle_reset_token(username: str, email: str, token: str):
-    """Handle the password reset token."""
-    base_url = current_app.config["BASE_URL"].rstrip("/")
-    send_email_reset_password(base_url=base_url, email=email, token=token)
 
 
 class UserTriggerResetPasswordResource(Resource):
@@ -240,7 +228,7 @@ class UserTriggerResetPasswordResource(Resource):
             expires_delta=datetime.timedelta(hours=1),
         )
         try:
-            handle_reset_token(username=user_name, email=email, token=token)
+            send_email_reset_password(email=email, token=token)
         except ValueError:
             abort(500)
         return "", 201

--- a/gramps_webapi/api/tasks.py
+++ b/gramps_webapi/api/tasks.py
@@ -2,19 +2,23 @@
 
 from gettext import gettext as _
 
+from flask import current_app
+
 from .emails import email_confirm_email, email_reset_pw
 from .util import send_email
 
 
-def send_email_reset_password(base_url: str, email: str, token: str):
+def send_email_reset_password(email: str, token: str):
     """Send an email for password reset."""
+    base_url = current_app.config["BASE_URL"].rstrip("/")
     body = email_reset_pw(base_url=base_url, token=token)
     subject = _("Reset your Gramps password")
     send_email(subject=subject, body=body, to=[email])
 
 
-def send_email_confirm_email(base_url: str, email: str, token: str):
+def send_email_confirm_email(email: str, token: str):
     """Send an email to confirm an e-mail address."""
+    base_url = current_app.config["BASE_URL"].rstrip("/")
     body = email_confirm_email(base_url=base_url, token=token)
     subject = _("Confirm your e-mail address")
     send_email(subject=subject, body=body, to=[email])

--- a/gramps_webapi/api/tasks.py
+++ b/gramps_webapi/api/tasks.py
@@ -1,3 +1,21 @@
+#
+# Gramps Web API - A RESTful API for the Gramps genealogy program
+#
+# Copyright (C) 2021      David Straub
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 """Execute tasks."""
 
 from gettext import gettext as _

--- a/gramps_webapi/api/tasks.py
+++ b/gramps_webapi/api/tasks.py
@@ -1,0 +1,20 @@
+"""Execute tasks."""
+
+from gettext import gettext as _
+
+from .emails import email_confirm_email, email_reset_pw
+from .util import send_email
+
+
+def send_email_reset_password(base_url: str, email: str, token: str):
+    """Send an email for password reset."""
+    body = email_reset_pw(base_url=base_url, token=token)
+    subject = _("Reset your Gramps password")
+    send_email(subject=subject, body=body, to=[email])
+
+
+def send_email_confirm_email(base_url: str, email: str, token: str):
+    """Send an email to confirm an e-mail address."""
+    body = email_confirm_email(base_url=base_url, token=token)
+    subject = _("Confirm your e-mail address")
+    send_email(subject=subject, body=body, to=[email])

--- a/gramps_webapi/api/tasks.py
+++ b/gramps_webapi/api/tasks.py
@@ -2,9 +2,9 @@
 
 from gettext import gettext as _
 
-from flask import current_app
+from flask import abort, current_app
 
-from .emails import email_confirm_email, email_reset_pw
+from .emails import email_confirm_email, email_new_user, email_reset_pw
 from .util import send_email
 
 
@@ -22,3 +22,18 @@ def send_email_confirm_email(email: str, token: str):
     body = email_confirm_email(base_url=base_url, token=token)
     subject = _("Confirm your e-mail address")
     send_email(subject=subject, body=body, to=[email])
+
+
+def send_email_new_user(username: str, fullname: str, email: str):
+    """Send an email to owners to notify of a new registered user."""
+    base_url = current_app.config["BASE_URL"].rstrip("/")
+    body = email_new_user(
+        base_url=base_url, username=username, fullname=fullname, email=email
+    )
+    subject = _("New registered user")
+    auth = current_app.config.get("AUTH_PROVIDER")
+    if auth is None:
+        abort(405)
+    emails = auth.get_owner_emails()
+    if emails:
+        send_email(subject=subject, body=body, to=emails)

--- a/gramps_webapi/auth/__init__.py
+++ b/gramps_webapi/auth/__init__.py
@@ -29,7 +29,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 
-from .const import PERMISSIONS
+from .const import PERMISSIONS, ROLE_OWNER
 from .passwords import hash_password, verify_password
 from .sql_guid import GUID
 
@@ -173,6 +173,12 @@ class SQLAuth:
         with self.session_scope() as session:
             user = session.query(User).filter_by(name=username).one()
             return PERMISSIONS[user.role]
+
+    def get_owner_emails(self) -> List[str]:
+        """Get e-mail addresses of all owners."""
+        with self.session_scope() as session:
+            owners = session.query(User).filter_by(role=ROLE_OWNER).all()
+            return [user.email for user in owners if user.email]
 
 
 class User(Base):

--- a/gramps_webapi/auth/__init__.py
+++ b/gramps_webapi/auth/__init__.py
@@ -134,6 +134,9 @@ class SQLAuth:
             user = session.query(User).filter_by(name=username).scalar()
             if user is None:
                 return False
+            if user.role < 0:
+                # users with negative roles cannot login!
+                return False
             return verify_password(password=password, salt_hash=user.pwhash)
 
     def get_pwhash(self, username: str) -> str:

--- a/gramps_webapi/auth/const.py
+++ b/gramps_webapi/auth/const.py
@@ -63,3 +63,8 @@ PERMISSIONS = {
     ROLE_MEMBER: {PERM_EDIT_OWN_USER, PERM_VIEW_PRIVATE,},
     ROLE_GUEST: {PERM_EDIT_OWN_USER,},
 }
+
+# keys/values for user claims
+CLAIM_LIMITED_SCOPE = "limited_scope"
+SCOPE_RESET_PW = "reset_password"
+SCOPE_CONF_EMAIL = "confirm_email"

--- a/gramps_webapi/auth/const.py
+++ b/gramps_webapi/auth/const.py
@@ -25,6 +25,9 @@ ROLE_EDITOR = 3
 ROLE_CONTRIBUTOR = 2
 ROLE_MEMBER = 1
 ROLE_GUEST = 0
+# Roles for unauthorized users
+ROLE_DISABLED = -1
+ROLE_UNCONFIRMED = -2
 
 # User permissions
 PERM_ADD_USER = "AddUser"

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -239,7 +239,7 @@ paths:
               description: An integer user role ID
               type: number
       responses:
-        200:
+        201:
           description: "OK: Successful operation."
         401:
           description: "Unauthorized: Missing authorization header."
@@ -248,6 +248,41 @@ paths:
         422:
           description: "Unprocessable Entity: Invalid token."
 
+  /users/{user_name}/register/:
+    post:
+      tags:
+      - users
+      summary: "Register a new user."
+      operationId: registerUser
+      parameters:
+      - name: user_name
+        in: path
+        required: true
+        type: string
+        description: "The user name or '-' for the authenticated user."
+      - name: user_details
+        in: body
+        schema:
+          type: object
+          properties:
+            email:
+              description: "The new user's e-mail address."
+              type: string
+            full_name:
+              description: "The new user's full name."
+              type: string
+            password:
+              description: "The new user's password."
+              type: string
+      responses:
+        201:
+          description: "OK: Successful operation."
+        401:
+          description: "Unauthorized: Missing authorization header."
+        409:
+          description: "Conflict: user already exists."
+        422:
+          description: "Unprocessable Entity: Invalid token."
 
   /users/{user_name}/password/change:
     post:
@@ -267,7 +302,7 @@ paths:
         in: header
         required: true
         type: string
-        description: "The JWT refresh token."
+        description: "The JWT access token."
       - name: passwords
         in: body
         required: true
@@ -293,15 +328,7 @@ paths:
         in: path
         required: true
         type: string
-        description: "The user name or '-' for the authenticated user."
-      - name: username
-        in: body
-        schema:
-          type: object
-          properties:
-            username:
-              description: "The username of the user whose password should be reset."
-              type: string
+        description: "The username of the user whose password should be reset."
       responses:
         201:
           description: "OK: e-mail successfully sent."
@@ -365,6 +392,29 @@ paths:
           description: "OK: Form or error message displayed."
         401:
           description: "Unauthorized: Missing authorization header."
+        405:
+          description: "Method Not Allowed: No authorization provider configured."
+
+
+  /users/-/email/confirm/:
+    get:
+      tags:
+      - users
+      summary: "Confirm the e-mail address after user registration."
+      operationId: confirmEmail
+      security:
+        - Bearer: []
+      parameters:
+      - name: Authorization
+        in: header
+        required: true
+        type: string
+        description: "The one-time confirmation token."
+      responses:
+        200:
+          description: "OK: e-mail successfully confirmed."
+        403:
+          description: "Forbidden: missing authorization."
         405:
           description: "Method Not Allowed: No authorization provider configured."
 

--- a/gramps_webapi/templates/confirmation.html
+++ b/gramps_webapi/templates/confirmation.html
@@ -1,0 +1,9 @@
+{% extends "reset_password_base.html" %}
+{% block title %}{{title}}{% endblock %}
+
+{% block main %}
+<div id="success" class="success" style="display:none;">
+  <img width="200" src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjxzdmcgaWQ9IkxheWVyXzEiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDYxMiA3OTI7IiB2ZXJzaW9uPSIxLjEiIHZpZXdCb3g9IjAgMCA2MTIgNzkyIiB4bWw6c3BhY2U9InByZXNlcnZlIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj48c3R5bGUgdHlwZT0idGV4dC9jc3MiPgoJLnN0MHtmaWxsOiM0MUFENDk7fQo8L3N0eWxlPjxnPjxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik01NjIsMzk2YzAtMTQxLjQtMTE0LjYtMjU2LTI1Ni0yNTZTNTAsMjU0LjYsNTAsMzk2czExNC42LDI1NiwyNTYsMjU2UzU2Miw1MzcuNCw1NjIsMzk2TDU2MiwzOTZ6ICAgIE01MDEuNywyOTYuM2wtMjQxLDI0MWwwLDBsLTE3LjIsMTcuMkwxMTAuMyw0MjEuM2w1OC44LTU4LjhsNzQuNSw3NC41bDE5OS40LTE5OS40TDUwMS43LDI5Ni4zTDUwMS43LDI5Ni4zeiIvPjwvZz48L3N2Zz4=">
+  <div>{{message}}</div>
+</div>
+{% endblock %}

--- a/tests/test_endpoints/test_user.py
+++ b/tests/test_endpoints/test_user.py
@@ -561,3 +561,10 @@ class TestUser(unittest.TestCase):
                     "name": "new_user_3",
                 },
             )
+            # try getting list of people with email confirmation token
+            # this should not be allowed!
+            rv = self.client.get(
+                BASE_URL + "/people/",
+                headers={"Authorization": "Bearer {}".format(token)},
+            )
+            self.assertEqual(rv.status_code, 401)

--- a/tests/test_endpoints/test_user.py
+++ b/tests/test_endpoints/test_user.py
@@ -27,7 +27,12 @@ from gramps.cli.clidbman import CLIDbManager
 from gramps.gen.dbstate import DbState
 
 from gramps_webapi.app import create_app
-from gramps_webapi.auth.const import ROLE_MEMBER, ROLE_OWNER, ROLE_UNCONFIRMED
+from gramps_webapi.auth.const import (
+    ROLE_DISABLED,
+    ROLE_MEMBER,
+    ROLE_OWNER,
+    ROLE_UNCONFIRMED,
+)
 from gramps_webapi.const import ENV_CONFIG_FILE, TEST_AUTH_CONFIG
 
 from . import BASE_URL
@@ -439,65 +444,120 @@ class TestUser(unittest.TestCase):
         assert rv.status_code == 200
 
     def test_register_user(self):
-        # role is not allowed
-        rv = self.client.post(
-            BASE_URL + "/users/new_user_2/register/",
-            json={
-                "email": "new_2@example.com",
-                "role": ROLE_OWNER,
-                "full_name": "My Name",
-                "password": "abc",
-            },
-        )
-        assert rv.status_code == 422
-        # missing password
-        rv = self.client.post(
-            BASE_URL + "/users/new_user_2/register/",
-            json={"email": "new_2@example.com", "full_name": "My Name",},
-        )
-        assert rv.status_code == 422
-        # existing user
-        rv = self.client.post(
-            BASE_URL + "/users/user/register/",
-            json={
-                "email": "new_2@example.com",
-                "full_name": "New Name",
-                "password": "abc",
-            },
-        )
-        assert rv.status_code == 409
-        # OK
-        rv = self.client.post(
-            BASE_URL + "/users/new_user_2/register/",
-            json={
-                "email": "new_2@example.com",
-                "full_name": "New Name",
-                "password": "abc",
-            },
-        )
-        assert rv.status_code == 201
-        # get owner token
-        rv = self.client.post(
-            BASE_URL + "/token/", json={"username": "owner", "password": "123"},
-        )
-        assert rv.status_code == 200
-        token_owner = rv.json["access_token"]
-        rv = self.client.get(
-            BASE_URL + "/users/new_user_2/",
-            headers={"Authorization": "Bearer {}".format(token_owner)},
-        )
-        assert rv.status_code == 200
-        self.assertEqual(
-            rv.json,
-            {
-                "email": "new_2@example.com",
-                "role": ROLE_UNCONFIRMED,
-                "full_name": "New Name",
-                "name": "new_user_2",
-            },
-        )
-        # new user cannot get token
-        rv = self.client.post(
-            BASE_URL + "/token/", json={"username": "new_user_2", "password": "abc"}
-        )
-        assert rv.status_code == 403
+        with patch("smtplib.SMTP") as mock_smtp:
+            # role is not allowed
+            rv = self.client.post(
+                BASE_URL + "/users/new_user_2/register/",
+                json={
+                    "email": "new_2@example.com",
+                    "role": ROLE_OWNER,
+                    "full_name": "My Name",
+                    "password": "abc",
+                },
+            )
+            assert rv.status_code == 422
+            # missing password
+            rv = self.client.post(
+                BASE_URL + "/users/new_user_2/register/",
+                json={"email": "new_2@example.com", "full_name": "My Name",},
+            )
+            assert rv.status_code == 422
+            # existing user
+            rv = self.client.post(
+                BASE_URL + "/users/user/register/",
+                json={
+                    "email": "new_2@example.com",
+                    "full_name": "New Name",
+                    "password": "abc",
+                },
+            )
+            assert rv.status_code == 409
+            # OK
+            rv = self.client.post(
+                BASE_URL + "/users/new_user_2/register/",
+                json={
+                    "email": "new_2@example.com",
+                    "full_name": "New Name",
+                    "password": "abc",
+                },
+            )
+            assert rv.status_code == 201
+            # get owner token
+            rv = self.client.post(
+                BASE_URL + "/token/", json={"username": "owner", "password": "123"},
+            )
+            assert rv.status_code == 200
+            token_owner = rv.json["access_token"]
+            rv = self.client.get(
+                BASE_URL + "/users/new_user_2/",
+                headers={"Authorization": "Bearer {}".format(token_owner)},
+            )
+            assert rv.status_code == 200
+            self.assertEqual(
+                rv.json,
+                {
+                    "email": "new_2@example.com",
+                    "role": ROLE_UNCONFIRMED,
+                    "full_name": "New Name",
+                    "name": "new_user_2",
+                },
+            )
+            # new user cannot get token
+            rv = self.client.post(
+                BASE_URL + "/token/", json={"username": "new_user_2", "password": "abc"}
+            )
+            assert rv.status_code == 403
+
+    def test_confirm_email(self):
+        with patch("smtplib.SMTP") as mock_smtp:
+            rv = self.client.post(
+                BASE_URL + "/users/new_user_3/register/",
+                json={
+                    "email": "new_3@example.com",
+                    "full_name": "New Name",
+                    "password": "abc",
+                },
+            )
+            assert rv.status_code == 201
+            context = mock_smtp.return_value
+            context.send_message.assert_called()
+            name, args, kwargs = context.method_calls.pop(0)
+            msg = args[0]
+            # extract the token from the message body
+            body = msg.get_body().get_payload().replace("=\n", "")
+            matches = re.findall(r".*jwt=([^\s]+).*", body)
+            self.assertEqual(len(matches), 1, msg=body)
+            token = matches[0]
+            if token[:2] == "3D":
+                token = token[2:]
+            # try without token
+            rv = self.client.get(BASE_URL + "/users/-/email/confirm/")
+            self.assertEqual(rv.status_code, 401)
+            # now that should work
+            rv = self.client.get(
+                BASE_URL + "/users/-/email/confirm/",
+                headers={"Authorization": "Bearer {}".format(token)},
+            )
+            self.assertEqual(rv.status_code, 200)
+            # get owner token
+            rv = self.client.post(
+                BASE_URL + "/token/", json={"username": "owner", "password": "123"},
+            )
+            assert rv.status_code == 200
+            token_owner = rv.json["access_token"]
+            # get user info
+            rv = self.client.get(
+                BASE_URL + "/users/new_user_3/",
+                headers={"Authorization": "Bearer {}".format(token_owner)},
+            )
+            assert rv.status_code == 200
+            # new role should be ROLE_DISABLED!
+            self.assertEqual(
+                rv.json,
+                {
+                    "email": "new_3@example.com",
+                    "role": ROLE_DISABLED,
+                    "full_name": "New Name",
+                    "name": "new_user_3",
+                },
+            )

--- a/tests/test_endpoints/test_user.py
+++ b/tests/test_endpoints/test_user.py
@@ -539,6 +539,8 @@ class TestUser(unittest.TestCase):
                 headers={"Authorization": "Bearer {}".format(token)},
             )
             self.assertEqual(rv.status_code, 200)
+            # check return template
+            self.assertIn(b"Thank you for confirming your e-mail address", rv.data)
             # get owner token
             rv = self.client.post(
                 BASE_URL + "/token/", json={"username": "owner", "password": "123"},


### PR DESCRIPTION
Implemented as described in #203.

One subtlety is that I noticed the e-mail confirmation link cannot just use a normal JWT as this would allow the self-registered (but not yet authorized) user to access API resources. To solve this issue, I introduced a new `limited_scope` key in the JWT user claims which is used for the e-mail confirmation and password reset links and which ensures that these particular tokens can only be used for their specific purposes, and not to fetch any information from the family tree.

As part of this PR, I also refactored the code to send e-mail notifications.