### PR TITLE
Fix tests with webargs 8.0.1

### DIFF
--- a/tests/test_endpoints/checks.py
+++ b/tests/test_endpoints/checks.py
@@ -48,11 +48,11 @@ def check_invalid_semantics(test, url, check="none", role=ROLE_OWNER):
     """Test that invalid parameters and values are handled properly."""
     check_list = {
         "none": [""],
-        "base": ["=,"],
+        "base": [],
         "boolean": ["=", "=-1", "=2", "=LoremIpsumDolorSitAmet"],
         "number": ["=", "=-1", "=0", "=LoremIpsumDolorSitAmet"],
         "integer": ["=", "=LoremIpsumDolorSitAmet"],
-        "list": ["=", "=LoremIpsumDolorSitAmet"],
+        "list": ["=LoremIpsumDolorSitAmet"],
     }
     header = fetch_header(test.client, role=role)
     for item in check_list[check]:

--- a/tests/test_endpoints/checks.py
+++ b/tests/test_endpoints/checks.py
@@ -48,7 +48,7 @@ def check_invalid_semantics(test, url, check="none", role=ROLE_OWNER):
     """Test that invalid parameters and values are handled properly."""
     check_list = {
         "none": [""],
-        "base": ["="],
+        "base": ["=,"],
         "boolean": ["=", "=-1", "=2", "=LoremIpsumDolorSitAmet"],
         "number": ["=", "=-1", "=0", "=LoremIpsumDolorSitAmet"],
         "integer": ["=", "=LoremIpsumDolorSitAmet"],
@@ -196,13 +196,7 @@ def check_paging_parameters(test, url, size, join="?", role=ROLE_OWNER):
 
 
 def check_sort_parameter(
-    test,
-    url,
-    sort_key,
-    value_key=None,
-    direction="+",
-    join="?",
-    role=ROLE_OWNER,
+    test, url, sort_key, value_key=None, direction="+", join="?", role=ROLE_OWNER,
 ):
     """Test that sort parameter produces expected result."""
     header = fetch_header(test.client, role=role)
@@ -229,13 +223,7 @@ def check_sort_parameter(
 
 
 def check_single_extend_parameter(
-    test,
-    url,
-    key,
-    extended_key,
-    join="?",
-    reference=False,
-    role=ROLE_OWNER,
+    test, url, key, extended_key, join="?", reference=False, role=ROLE_OWNER,
 ):
     """Test that extend parameter produces expected result for a single key."""
 

--- a/tests/test_endpoints/test_people.py
+++ b/tests/test_endpoints/test_people.py
@@ -1031,7 +1031,7 @@ class TestPeopleHandle(unittest.TestCase):
     def test_get_people_handle_parameter_backlinks_validate_semantics(self):
         """Test invalid backlinks parameter and values."""
         check_invalid_semantics(
-            self, TEST_URL + "0PWJQCZYFXOS0HGREE?profile", check="boolean"
+            self, TEST_URL + "0PWJQCZYFXOS0HGREE?profile", check="list"
         )
 
     def test_get_people_handle_parameter_backlinks_expected_result(self):


### PR DESCRIPTION
A small change in [webargs 8.0.1](https://webargs.readthedocs.io/en/latest/changelog.html) lead to many tests suddenly failing. This should make them pass again.