### PR TITLE
User docker development image for demo

### DIFF
--- a/demo/Dockerfile
+++ b/demo/Dockerfile
@@ -1,4 +1,4 @@
-FROM dmstraub/gramps-webapi:latest
+FROM dmstraub/gramps-webapi:latest-devel
 
 # copy config file
 COPY config.cfg /app/config/


### PR DESCRIPTION
Since #195, the latest released version is used for the demo, but IMO it makes more sense to use the current development version.