### PR TITLE
Update person family handles when adding a family (fixes #209)

### DIFF
--- a/gramps_webapi/api/resources/base.py
+++ b/gramps_webapi/api/resources/base.py
@@ -266,9 +266,10 @@ class GrampsObjectResource(GrampsObjectResourceHelper, Resource):
         # update search index
         indexer: SearchIndexer = current_app.config["SEARCH_INDEXER"]
         with indexer.get_writer(overwrite=False, use_async=True) as writer:
-            indexer.add_or_update_object(
-                writer, handle, db_handle, self.gramps_class_name
-            )
+            for _trans_dict in trans_dict:
+                handle = _trans_dict["handle"]
+                class_name = _trans_dict["_class"]
+                indexer.add_or_update_object(writer, handle, db_handle, class_name)
         return self.response(200, trans_dict, total_items=len(trans_dict))
 
 
@@ -409,13 +410,11 @@ class GrampsObjectsResource(GrampsObjectResourceHelper, Resource):
             trans_dict = transaction_to_json(trans)
         # update search index
         indexer: SearchIndexer = current_app.config["SEARCH_INDEXER"]
-        # get the new handle from the transaction dict, in case it was not specified
-        # explicitly
-        handle = trans_dict[0]["handle"]
         with indexer.get_writer(overwrite=False, use_async=True) as writer:
-            indexer.add_or_update_object(
-                writer, handle, db_handle, self.gramps_class_name
-            )
+            for _trans_dict in trans_dict:
+                handle = _trans_dict["handle"]
+                class_name = _trans_dict["_class"]
+                indexer.add_or_update_object(writer, handle, db_handle, class_name)
         return self.response(201, trans_dict, total_items=len(trans_dict))
 
 

--- a/gramps_webapi/api/resources/families.py
+++ b/gramps_webapi/api/resources/families.py
@@ -22,11 +22,13 @@
 
 from typing import Dict
 
-from flask import abort
+from flask import Response, abort
 from gramps.gen.const import GRAMPS_LOCALE as glocale
 from gramps.gen.lib import Family
 from gramps.gen.utils.grampslocale import GrampsLocale
 
+from ...auth.const import PERM_ADD_OBJ, PERM_EDIT_OBJ
+from ..auth import require_permissions
 from .base import (
     GrampsObjectProtectedResource,
     GrampsObjectResourceHelper,
@@ -72,3 +74,13 @@ class FamilyResource(GrampsObjectProtectedResource, FamilyResourceHelper):
 
 class FamiliesResource(GrampsObjectsProtectedResource, FamilyResourceHelper):
     """Families resource."""
+
+    def post(self) -> Response:
+        """Post a new object.
+
+        The parent class's method is overridden since creating a Family object
+        modifies the family members' Person objects as well, so `PERM_EDIT_OBJ`
+        is required.
+        """
+        require_permissions([PERM_ADD_OBJ, PERM_EDIT_OBJ])
+        return GrampsObjectsProtectedResource.post(self)


### PR DESCRIPTION
This fixes #209.

Changes:

- When adding or updating families via `POST` to `/api/families/` or `/api/objects/` or via `PUT` to `/api/families/<handle>`, the family members' person objects are modified to update their `family_list` and `parent_family_list` attributes, analogously to what is done in `gramps.gui.editors.editfamily.save`.
- The search index is updated accordingly
- Posting a family (to either of the two endpoints) will fail if the `EditObject` permission is not present in the token (as the person objects are modified).