### PR TITLE
Allow using the same JSON format for GET, POST, and PUT

### DIFF
--- a/gramps_webapi/api/resources/base.py
+++ b/gramps_webapi/api/resources/base.py
@@ -142,7 +142,10 @@ class GrampsObjectResourceHelper(GrampsJSONEncoder):
             obj_dict["_class"] = self.gramps_class_name
         elif obj_dict["_class"] != self.gramps_class_name:
             abort(400)
-        obj_dict = fix_object_dict(obj_dict)
+        try:
+            obj_dict = fix_object_dict(obj_dict)
+        except ValueError:
+            abort(400)
         if not validate_object_dict(obj_dict):
             abort(400)
         return from_json(json.dumps(obj_dict))

--- a/gramps_webapi/api/resources/base.py
+++ b/gramps_webapi/api/resources/base.py
@@ -45,6 +45,7 @@ from .match import match_dates
 from .sort import sort_objects
 from .util import (
     add_object,
+    fix_object_dict,
     get_backlinks,
     get_extended_attributes,
     get_reference_profile_for_object,
@@ -141,6 +142,7 @@ class GrampsObjectResourceHelper(GrampsJSONEncoder):
             obj_dict["_class"] = self.gramps_class_name
         elif obj_dict["_class"] != self.gramps_class_name:
             abort(400)
+        obj_dict = fix_object_dict(obj_dict)
         if not validate_object_dict(obj_dict):
             abort(400)
         return from_json(json.dumps(obj_dict))

--- a/gramps_webapi/api/resources/objects.py
+++ b/gramps_webapi/api/resources/objects.py
@@ -43,7 +43,10 @@ class CreateObjectsResource(ProtectedResource):
         payload = request.json
         objects = []
         for obj_dict in payload:
-            obj_dict = fix_object_dict(obj_dict)
+            try:
+                obj_dict = fix_object_dict(obj_dict)
+            except ValueError:
+                abort(400)
             if not validate_object_dict(obj_dict):
                 abort(400)
             obj = from_json(json.dumps(obj_dict))

--- a/gramps_webapi/api/resources/objects.py
+++ b/gramps_webapi/api/resources/objects.py
@@ -32,7 +32,7 @@ from ..auth import require_permissions
 from ..search import SearchIndexer
 from ..util import get_db_handle
 from . import ProtectedResource
-from .util import add_object, transaction_to_json, validate_object_dict
+from .util import add_object, fix_object_dict, transaction_to_json, validate_object_dict
 
 
 class CreateObjectsResource(ProtectedResource):
@@ -43,6 +43,7 @@ class CreateObjectsResource(ProtectedResource):
         payload = request.json
         objects = []
         for obj_dict in payload:
+            obj_dict = fix_object_dict(obj_dict)
             if not validate_object_dict(obj_dict):
                 abort(400)
             obj = from_json(json.dumps(obj_dict))

--- a/gramps_webapi/api/resources/util.py
+++ b/gramps_webapi/api/resources/util.py
@@ -805,20 +805,25 @@ def fix_object_dict(object_dict: Dict, class_name: Optional[str] = None):
     d_out["_class"] = class_name
     for k, v in object_dict.items():
         # convert type back to dict and translate type name
-        is_grampstype = k in [
-            "type",
-            "place_type",
-            "media_type",
-            "origintype",
-            "role",
-            "frel",
-            "mrel",
-        ] or (k == "name" and class_name == "StyledTextTag")
-        if is_grampstype:
+        if k in ["type", "place_type", "media_type", "frel", "mrel"] or (
+            k == "name" and class_name == "StyledTextTag"
+        ):
             if isinstance(v, str):
                 d_out[k] = {"_class": f"{class_name}Type", "string": _(v)}
             else:
                 d_out[k] = v
+        elif k == "role":
+            if isinstance(v, str):
+                d_out[k] = {"_class": "EventRoleType", "string": _(v)}
+            else:
+                d_out[k] = v
+        elif k == "origintype":
+            if isinstance(v, str):
+                d_out[k] = {"_class": "NameOriginType", "string": _(v)}
+            else:
+                d_out[k] = v
+        elif k in ["rect", "mother_handle", "father_handle", "famc"] and not v:
+            d_out[k] = None
         elif isinstance(v, dict):
             d_out[k] = fix_object_dict(v, _get_class_name(class_name, k))
         elif isinstance(v, list):

--- a/gramps_webapi/api/resources/util.py
+++ b/gramps_webapi/api/resources/util.py
@@ -51,7 +51,7 @@ from gramps.gen.lib import (
     Tag,
 )
 from gramps.gen.lib.primaryobj import BasicPrimaryObject as GrampsObject
-from gramps.gen.lib.serialize import to_json
+from gramps.gen.lib.serialize import from_json, to_json
 from gramps.gen.soundex import soundex
 from gramps.gen.utils.db import (
     get_birth_or_fallback,
@@ -66,6 +66,7 @@ from ...const import SEX_FEMALE, SEX_MALE, SEX_UNKNOWN
 from ...types import Handle
 
 pd = PlaceDisplay()
+_ = glocale.translation.gettext
 
 
 def get_person_by_handle(db_handle: DbReadBase, handle: Handle) -> Union[Person, Dict]:
@@ -787,6 +788,90 @@ def validate_object_dict(obj_dict: Dict[str, Any]) -> bool:
     except jsonschema.exceptions.ValidationError:
         return False
     return True
+
+
+def fix_object_dict(object_dict: Dict, class_name: Optional[str] = None):
+    """Restore a Gramps object in simplified representation to its full form.
+
+    This restores in particular:
+    - class names
+    - Gramps types are turned from strings into dictionaries
+    - Gramps type names are translated to the default Gramps locale
+    """
+    d_out = {}
+    class_name = class_name or object_dict.get("_class")
+    if not class_name:
+        raise ValueError("No class name specified!")
+    d_out["_class"] = class_name
+    for k, v in object_dict.items():
+        # convert type back to dict and translate type name
+        is_grampstype = k in [
+            "type",
+            "place_type",
+            "media_type",
+            "origintype",
+            "role",
+            "frel",
+            "mrel",
+        ] or (k == "name" and class_name == "StyledTextTag")
+        if is_grampstype:
+            if isinstance(v, str):
+                d_out[k] = {"_class": f"{class_name}Type", "string": _(v)}
+            else:
+                d_out[k] = v
+        elif isinstance(v, dict):
+            d_out[k] = fix_object_dict(v, _get_class_name(class_name, k))
+        elif isinstance(v, list):
+            d_out[k] = [
+                fix_object_dict(item, _get_class_name(class_name, k))
+                if isinstance(item, dict)
+                else item
+                for item in v
+            ]
+        else:
+            d_out[k] = v
+    return d_out
+
+
+def _get_class_name(super_name, key_name) -> str:
+    """Get the correct Gramps class name for a given key in a class dict."""
+    if key_name == "date":
+        return "Date"
+    if key_name == "media_list":
+        return "MediaRef"
+    if key_name == "child_ref_list":
+        return "ChildRef"
+    if key_name == "event_ref_list":
+        return "EventRef"
+    if key_name == "address_list":
+        return "Address"
+    if key_name == "urls":
+        return "Url"
+    if key_name == "lds_ord_list":
+        return "LdsOrd"
+    if key_name == "person_ref_list":
+        return "PersonRef"
+    if key_name == "surname_list":
+        return "Surname"
+    if key_name == "text":
+        return "StyledText"
+    if key_name == "place_type":
+        return "PlaceType"
+    if key_name == "alt_loc":
+        return "Location"
+    if key_name == "reporef_list":
+        return "RepoRef"
+    if key_name == "tags":
+        return "StyledTextTag"
+    if (key_name == "name" and super_name == "Place") or key_name == "alt_names":
+        return "PlaceName"
+    if key_name in ["primary_name", "alternate_names"]:
+        return "Name"
+    if key_name == "attribute_list" and super_name == "Citation":
+        return "SrcAttribute"
+    elif key_name == "attribute_list":
+        return "Attribute"
+    raise ValueError(f"Unknown classes: {super_name}, {key_name}")
 
 
 def update_object(

--- a/gramps_webapi/api/resources/util.py
+++ b/gramps_webapi/api/resources/util.py
@@ -861,6 +861,8 @@ def _get_class_name(super_name, key_name) -> str:
         return "Location"
     if key_name == "reporef_list":
         return "RepoRef"
+    if key_name == "placeref_list":
+        return "PlaceRef"
     if key_name == "tags":
         return "StyledTextTag"
     if (key_name == "name" and super_name == "Place") or key_name == "alt_names":


### PR DESCRIPTION
Implementing the UI for adding & updating objects in Gramps.js, I realized there was an issue with the current implementation of putting or posting objects to the API: it is assumed that they follow the same JSON structure as Gramps' own JSON methods in `gramps.gen.lib.serialize`. However, I had forgotten that the JSON objects we return are slightly different even for default query parameters:
- The `_class` attribute is always missing from JSON objects
- Types are represented as strings rather than as `GrampsType` objects, and the string is untranslated, while Gramps uses strings in the default locale. So, for a birth event, we have `{'type': 'Birth'}`, while Gramps, on a German locale, would serialize as `{'type': {'_class': 'EventType', 'string': 'Geburt'}`

The problem with this difference is that it would be impossible to fetch an object via `GET`, modify some values, and update the object again via `PUT`, since `PUT` expects the "raw" Gramps format.

The solution in this PR is a new function `fix_object_dict` called in the `post` and `put` methods, which simply inserts the `_class` attributes in the right places and turns the type strings into localized dicts, if necessary.

This way, the user is free to post/put objects either in the "raw" Gramps format or using the simplified format that is used for `GET`, and both will work the same way.