### PR TITLE
Forward logs to gunicorn

### DIFF
--- a/gramps_webapi/app.py
+++ b/gramps_webapi/app.py
@@ -42,6 +42,12 @@ def create_app(db_manager=None):
 
     app.logger.setLevel(logging.INFO)
 
+    # when using gunicorn, make sure flask log messages are shown
+    gunicorn_logger = logging.getLogger("gunicorn.error")
+    app.logger.handlers = gunicorn_logger.handlers
+    app.logger.setLevel(gunicorn_logger.level)
+    app.logger.error(gunicorn_logger.level)
+
     # load default config
     app.config.from_object(DefaultConfig)
 


### PR DESCRIPTION
This makes sure flask log messages are shown when using gunicorn, see e.g. https://stackoverflow.com/questions/26578733/why-is-flask-application-not-creating-any-logs-when-hosted-by-gunicorn

I will merge this immediately since I need it to debug #222.