### PR TITLE
Allow configuring from environment, add docker entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,10 @@ RUN mkdir /app/static && touch /app/static/index.html
 RUN mkdir /app/db && mkdir /app/media && mkdir /app/indexdir && mkdir /app/users
 RUN mkdir /app/thumbnail_cache
 RUN mkdir /app/tmp
+ENV USER_DB_URI=sqlite:////app/users/users.sqlite
+ENV MEDIA_BASE_DIR=/app/media
+ENV SEARCH_INDEX_DIR=/app/indexdir
+ENV STATIC_PATH=/app/static
 
 # install gunicorn
 RUN python3 -m pip install --no-cache-dir --extra-index-url https://www.piwheels.org/simple \
@@ -32,4 +36,6 @@ RUN python3 -m pip install --no-cache-dir --extra-index-url https://www.piwheels
 
 EXPOSE 5000
 
+COPY docker-entrypoint.sh /
+ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD gunicorn -w 8 -b 0.0.0.0:5000 gramps_webapi.wsgi:app --timeout 120 --limit-request-line 8190

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+set -eu
+
+# Use Gramps.js frontend
+if [ -n "$GRAMPSJS_VERSION" ]
+then
+    # Download if necessary
+    if ! [ -d "/app/static/grampsjs-${GRAMPSJS_VERSION}" ]
+    then
+        wget "https://github.com/DavidMStraub/Gramps.js/releases/download/${GRAMPSJS_VERSION}/grampsjs-${GRAMPSJS_VERSION}.tar.gz"
+        tar -xzf "grampsjs-${GRAMPSJS_VERSION}.tar.gz"
+        mv "grampsjs-${GRAMPSJS_VERSION}" static/
+    fi
+    export STATIC_PATH="/app/static/grampsjs-${GRAMPSJS_VERSION}"
+fi
+
+# Recreate search index if not exists
+if [ -z "$(ls -A /app/indexdir)" ]
+then
+    python3 -m gramps_webapi --config /app/config/config.cfg search index-full
+fi
+
+exec "$@"

--- a/gramps_webapi/__main__.py
+++ b/gramps_webapi/__main__.py
@@ -34,11 +34,12 @@ LOG = logging.getLogger("gramps_webapi")
 
 
 @click.group("cli")
-@click.option("--config", help="Set the path to the config file", required=True)
+@click.option("--config", help="Set the path to the config file")
 @click.pass_context
 def cli(ctx, config):
     """Gramps web API command line interface."""
-    os.environ[ENV_CONFIG_FILE] = os.path.abspath(config)
+    if config:
+        os.environ[ENV_CONFIG_FILE] = os.path.abspath(config)
     ctx.obj = create_app()
 
 

--- a/gramps_webapi/config.py
+++ b/gramps_webapi/config.py
@@ -20,22 +20,23 @@
 """Default configuration settings."""
 
 import datetime
+import os
 
 
 class DefaultConfig(object):
     """Default configuration object."""
 
     PROPAGATE_EXCEPTIONS = True
-    SEARCH_INDEX_DIR = "indexdir"
-    EMAIL_HOST = "localhost"
-    EMAIL_PORT = 0
-    EMAIL_HOST_USER = ""
-    EMAIL_HOST_PASSWORD = ""
-    EMAIL_USE_TLS = False
-    DEFAULT_FROM_EMAIL = ""
-    BASE_URL = "http://localhost/"
+    SEARCH_INDEX_DIR = os.getenv("SEARCH_INDEX_DIR", "indexdir")
+    EMAIL_HOST = os.getenv("EMAIL_HOST", "localhost")
+    EMAIL_PORT = int(os.getenv("EMAIL_PORT", "465"))
+    EMAIL_HOST_USER = os.getenv("EMAIL_HOST_USER", "")
+    EMAIL_HOST_PASSWORD = os.getenv("EMAIL_HOST_PASSWORD", "")
+    EMAIL_USE_TLS = True
+    DEFAULT_FROM_EMAIL = os.getenv("DEFAULT_FROM_EMAIL", "")
+    BASE_URL = os.getenv("BASE_URL", "http://localhost/")
     CORS_EXPOSE_HEADERS = ["X-Total-Count"]
-    STATIC_PATH = "static"
+    STATIC_PATH = os.getenv("STATIC_PATH", "static")
     THUMBNAIL_CACHE_CONFIG = {
         "CACHE_TYPE": "filesystem",
         "CACHE_DIR": "thumbnail_cache",


### PR DESCRIPTION
The aim of this PR is to simplify the docker deployment process. It is still marked as draft as I also need to update the documentation.

Changes:
- The most important config variables can now be specified as environment variables. This has two advantages:
    - In most cases one can set up docker compose without the need to create and mount a config file
    - The settings that always need to be the same when using docker (the paths to the directories in the container) can be set as env vars in the image itself, so no need to specify in the config anymore
- The search index is now created on container creation, if it does not exist yet
- When the environment variable `GRAMPSJS_VERSION` is set, the Gramps.js frontend (corresponding to that released version) is downloaded into the static asset directory. This means users can decide with a simple env var if they want to use the API alone or add the Gramps.js frontend.