### PR TITLE
Fix issue with source media type

### DIFF
--- a/gramps_webapi/api/resources/util.py
+++ b/gramps_webapi/api/resources/util.py
@@ -852,6 +852,11 @@ def fix_object_dict(object_dict: Dict, class_name: Optional[str] = None):
                         "_class": f"{class_name}RelType",
                         "string": xml_to_locale(f"{class_name}RelType", v),
                     }
+                elif class_name == "RepoRef":
+                    d_out[k] = {
+                        "_class": "SourceMediaType",
+                        "string": xml_to_locale("SourceMediaType", v),
+                    }
                 else:
                     d_out[k] = {
                         "_class": f"{class_name}Type",


### PR DESCRIPTION
I noticed another issue with the `fix_object_dict` function: it did not correctly handle `RepoRef` instances with a `SourceMediaType`. This is now fixed.