### PR TITLE
Use locale for media object profile

### DIFF
--- a/gramps_webapi/api/resources/media.py
+++ b/gramps_webapi/api/resources/media.py
@@ -57,7 +57,7 @@ class MediaObjectResourceHelper(GrampsObjectResourceHelper):
         """Extend media attributes as needed."""
         if "profile" in args:
             obj.profile = get_media_profile_for_object(
-                self.db_handle, obj, args["profile"]
+                self.db_handle, obj, args["profile"], locale=locale
             )
         if "extend" in args:
             obj.extended = get_extended_attributes(self.db_handle, obj, args)


### PR DESCRIPTION
And another 1-line PR: I noticed in Gramps.js that date strings in media views were not localized. This is because the `locale` parameter was missing in a call. Added.