### PR TITLE
Allow JWT in header string for exporters

### DIFF
--- a/gramps_webapi/api/resources/exporters.py
+++ b/gramps_webapi/api/resources/exporters.py
@@ -215,6 +215,7 @@ class ExporterFileResource(ProtectedResource, GrampsJSONEncoder):
             ),
             "translate_headers": fields.Boolean(missing=True),
             "years_after_death": fields.Integer(missing=0),
+            "jwt": fields.String(required=False),
         },
         location="query",
     )


### PR DESCRIPTION
Simple change: allow the JWT also in the query string for exported files (as we already do for media files).

This is necessary for my frontend exporter implementation (https://github.com/gramps-project/Gramps.js/issues/43).