### PR TITLE
Add support for PostgreSQL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,16 @@
 FROM dmstraub/gramps:5.1.4
 
+ENV GRAMPS_VERSION=51
 WORKDIR /app
 ENV PYTHONPATH="${PYTHONPATH}:/usr/lib/python3/dist-packages"
 
-# install poppler (needed for PDF thumbnails) and ffmpeg (needed for video thumbnails)
+# install poppler (needed for PDF thumbnails)
+# ffmpeg (needed for video thumbnails)
+# postgresql client (needed for PostgreSQL backend)
 RUN apt-get update && apt-get install -y \
   poppler-utils ffmpeg libavcodec-extra \
+  unzip \
+  libpq-dev postgresql-client postgresql-client-common python3-psycopg2 \
   && rm -rf /var/lib/apt/lists/*
 
 # set locale
@@ -22,10 +27,16 @@ RUN mkdir /app/static && touch /app/static/index.html
 RUN mkdir /app/db && mkdir /app/media && mkdir /app/indexdir && mkdir /app/users
 RUN mkdir /app/thumbnail_cache
 RUN mkdir /app/tmp
+RUN mkdir -p /root/.gramps/gramps$GRAMPS_VERSION
 ENV USER_DB_URI=sqlite:////app/users/users.sqlite
 ENV MEDIA_BASE_DIR=/app/media
 ENV SEARCH_INDEX_DIR=/app/indexdir
 ENV STATIC_PATH=/app/static
+
+# install PostgreSQL addon
+RUN wget https://github.com/gramps-project/addons/archive/refs/heads/master.zip \
+    && unzip -p master.zip addons-master/gramps$GRAMPS_VERSION/download/PostgreSQL.addon.tgz | \
+    tar -xvz -C /root/.gramps/gramps$GRAMPS_VERSION/plugins && rm master.zip
 
 # install gunicorn
 RUN python3 -m pip install --no-cache-dir --extra-index-url https://www.piwheels.org/simple \

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,4 +51,4 @@ EXPOSE 5000
 
 COPY docker-entrypoint.sh /
 ENTRYPOINT ["/docker-entrypoint.sh"]
-CMD gunicorn -w 8 -b 0.0.0.0:5000 gramps_webapi.wsgi:app --timeout 120 --limit-request-line 8190
+CMD gunicorn -w ${GUNICORN_NUM_WORKERS:-8} -b 0.0.0.0:5000 gramps_webapi.wsgi:app --timeout 120 --limit-request-line 8190

--- a/gramps_webapi/app.py
+++ b/gramps_webapi/app.py
@@ -65,6 +65,9 @@ def create_app(db_manager=None):
     if not app.config.get("SECRET_KEY") and not app.config.get("DISABLE_AUTH"):
         raise ValueError("SECRET_KEY must be specified")
 
+    # if postgresql password is missing, try to get  it from the env
+    app.config["POSTGRES_PASSWORD"] = app.config["POSTGRES_PASSWORD"] or os.getenv("POSTGRES_PASSWORD")
+
     # try setting media basedir from environment
     app.config["MEDIA_BASE_DIR"] = app.config.get("MEDIA_BASE_DIR") or os.getenv(
         "MEDIA_BASE_DIR"
@@ -72,7 +75,10 @@ def create_app(db_manager=None):
 
     # instantiate DB manager
     if db_manager is None:
-        app.config["DB_MANAGER"] = WebDbManager(name=app.config["TREE"])
+        app.config["DB_MANAGER"] = WebDbManager(
+            name=app.config["TREE"],
+            password=app.config["POSTGRES_PASSWORD"],
+        )
     else:
         app.config["DB_MANAGER"] = db_manager
 

--- a/gramps_webapi/config.py
+++ b/gramps_webapi/config.py
@@ -42,6 +42,7 @@ class DefaultConfig(object):
         "CACHE_DIR": "thumbnail_cache",
         "CACHE_THRESHOLD": 1000,
     }
+    POSTGRES_PASSWORD = None
 
 
 class DefaultConfigJWT(object):

--- a/gramps_webapi/dbmanager.py
+++ b/gramps_webapi/dbmanager.py
@@ -25,6 +25,8 @@
 
 import os
 
+from typing import Optional
+
 from gramps.cli.clidbman import CLIDbManager
 from gramps.cli.user import User
 from gramps.gen.config import config
@@ -38,11 +40,12 @@ from .dbloader import WebDbSessionManager
 class WebDbManager:
     """Database manager class based on Gramps CLI."""
 
-    ALLOWED_DB_BACKENDS = ["sqlite"]
+    ALLOWED_DB_BACKENDS = ["sqlite", "postgresql"]
 
-    def __init__(self, name: str) -> None:
+    def __init__(self, name: str, password: Optional[str] = None) -> None:
         """Initialize given a family tree name."""
         self.name = name
+        self.password = password
         self.path = self._get_path()
         self._check_backend()
 
@@ -93,5 +96,5 @@ class WebDbManager:
         if force_unlock:
             self.break_lock()
         mode = DBMODE_R if readonly else DBMODE_W
-        smgr.open_activate(self.path, mode=mode)
+        smgr.open_activate(self.path, mode=mode, password=self.password)
         return dbstate


### PR DESCRIPTION
- Pass POSTGRESQL_PASSWORD environment variable to Database Manager to open PostgreSQL.
- Install the required prerequisites for PostgreSQL in the Docker container.

Also see PR #260 for previous comments on this feature...