### PR TITLE
Implement media file storage on S3-compatible object storage (fixes #237)

### DIFF
--- a/gramps_webapi/api/__init__.py
+++ b/gramps_webapi/api/__init__.py
@@ -261,7 +261,7 @@ register_endpt(
 @thumbnail_cache.cached(make_cache_key=make_cache_key_thumbnails)
 def get_thumbnail(args, handle, size):
     """Get a file's thumbnail."""
-    base_dir = current_app.config.get("MEDIA_BASE_DIR")
+    base_dir = current_app.config.get("MEDIA_BASE_DIR", "")
     handler = MediaHandler(base_dir).get_file_handler(handle)
     return handler.send_thumbnail(size=size, square=args["square"])
 

--- a/gramps_webapi/api/__init__.py
+++ b/gramps_webapi/api/__init__.py
@@ -27,7 +27,7 @@ from webargs import fields, validate
 
 from ..const import API_PREFIX
 from .auth import jwt_required_ifauth
-from .file import LocalFileHandler
+from .media import MediaHandler
 from .resources.base import Resource
 from .resources.bookmarks import BookmarkResource, BookmarksResource
 from .resources.citations import CitationResource, CitationsResource
@@ -172,10 +172,14 @@ register_endpt(TranslationResource, "/translations/<string:language>", "translat
 register_endpt(TranslationsResource, "/translations/", "translations")
 # Relations
 register_endpt(
-    RelationResource, "/relations/<string:handle1>/<string:handle2>", "relation",
+    RelationResource,
+    "/relations/<string:handle1>/<string:handle2>",
+    "relation",
 )
 register_endpt(
-    RelationsResource, "/relations/<string:handle1>/<string:handle2>/all", "relations",
+    RelationsResource,
+    "/relations/<string:handle1>/<string:handle2>/all",
+    "relations",
 )
 # Living
 register_endpt(LivingDatesResource, "/living/<string:handle>/dates", "living-dates")
@@ -203,16 +207,24 @@ register_endpt(HolidaysResource, "/holidays/", "holidays")
 register_endpt(MetadataResource, "/metadata/", "metadata")
 # User
 register_endpt(
-    UsersResource, "/users/", "users",
+    UsersResource,
+    "/users/",
+    "users",
 )
 register_endpt(
-    UserResource, "/users/<string:user_name>/", "user",
+    UserResource,
+    "/users/<string:user_name>/",
+    "user",
 )
 register_endpt(
-    UserRegisterResource, "/users/<string:user_name>/register/", "register",
+    UserRegisterResource,
+    "/users/<string:user_name>/register/",
+    "register",
 )
 register_endpt(
-    UserConfirmEmailResource, "/users/-/email/confirm/", "confirm_email",
+    UserConfirmEmailResource,
+    "/users/-/email/confirm/",
+    "confirm_email",
 )
 register_endpt(
     UserChangePasswordResource,
@@ -220,7 +232,9 @@ register_endpt(
     "change_password",
 )
 register_endpt(
-    UserResetPasswordResource, "/users/-/password/reset/", "reset_password",
+    UserResetPasswordResource,
+    "/users/-/password/reset/",
+    "reset_password",
 )
 register_endpt(
     UserTriggerResetPasswordResource,
@@ -231,7 +245,9 @@ register_endpt(
 register_endpt(SearchResource, "/search/", "search")
 
 register_endpt(
-    MediaFileResource, "/media/<string:handle>/file", "media_file",
+    MediaFileResource,
+    "/media/<string:handle>/file",
+    "media_file",
 )
 
 
@@ -246,7 +262,7 @@ register_endpt(
 def get_thumbnail(args, handle, size):
     """Get a file's thumbnail."""
     base_dir = current_app.config.get("MEDIA_BASE_DIR")
-    handler = LocalFileHandler(handle, base_dir)
+    handler = MediaHandler(base_dir).get_file_handler(handle)
     return handler.send_thumbnail(size=size, square=args["square"])
 
 
@@ -261,8 +277,8 @@ def get_thumbnail(args, handle, size):
 @thumbnail_cache.cached(make_cache_key=make_cache_key_thumbnails)
 def get_cropped(args, handle: str, x1: int, y1: int, x2: int, y2: int):
     """Get the thumbnail of a cropped file."""
-    base_dir = current_app.config.get("MEDIA_BASE_DIR")
-    handler = LocalFileHandler(handle, base_dir)
+    base_dir = current_app.config.get("MEDIA_BASE_DIR", "")
+    handler = MediaHandler(base_dir).get_file_handler(handle)
     return handler.send_cropped(x1=x1, y1=y1, x2=x2, y2=y2, square=args["square"])
 
 
@@ -279,8 +295,8 @@ def get_thumbnail_cropped(
     args, handle: str, x1: int, y1: int, x2: int, y2: int, size: int
 ):
     """Get the thumbnail of a cropped file."""
-    base_dir = current_app.config.get("MEDIA_BASE_DIR")
-    handler = LocalFileHandler(handle, base_dir)
+    base_dir = current_app.config.get("MEDIA_BASE_DIR", "")
+    handler = MediaHandler(base_dir).get_file_handler(handle)
     return handler.send_thumbnail_cropped(
         size=size, x1=x1, y1=y1, x2=x2, y2=y2, square=args["square"]
     )

--- a/gramps_webapi/api/file.py
+++ b/gramps_webapi/api/file.py
@@ -145,7 +145,7 @@ class LocalFileHandler(FileHandler):
         return send_file(buffer, mimetype=MIME_JPEG)
 
 
-def upload_file(base_dir, stream: BinaryIO, checksum: str, mime: str) -> str:
+def upload_file_local(base_dir, stream: BinaryIO, checksum: str, mime: str) -> str:
     """Upload a file from a stream, returning the file path."""
     base_dir = base_dir or get_media_base_dir()
     if not mime:

--- a/gramps_webapi/api/file.py
+++ b/gramps_webapi/api/file.py
@@ -38,7 +38,7 @@ from .util import get_db_handle, get_media_base_dir
 
 
 class FileHandler:
-    """Generic media file handler."""
+    """Generic handler for a single media file."""
 
     def __init__(self, handle):
         """Initialize self."""
@@ -60,6 +60,10 @@ class FileHandler:
         """Send media file to client."""
         raise NotImplementedError
 
+    def send_cropped(self, x1: int, y1: int, x2: int, y2: int, square: bool = False):
+        """Send cropped media file to client."""
+        raise NotImplementedError
+
     def send_thumbnail(self, size: int, square: bool = False):
         """Send thumbnail of image."""
         raise NotImplementedError
@@ -79,7 +83,7 @@ class LocalFileHandler(FileHandler):
         super().__init__(handle)
         self.base_dir = base_dir or get_media_base_dir()
         if not os.path.isdir(self.base_dir):
-            raise ValueError("Directory {} does not exist".format(self.base_dir))
+            raise ValueError(f"Directory {self.base_dir} does not exist")
         if os.path.isabs(self.path):
             self.path_abs = self.path
             self.path_rel = os.path.relpath(self.path, self.base_dir)
@@ -95,9 +99,7 @@ class LocalFileHandler(FileHandler):
         base_dir = Path(self.base_dir).resolve()
         file_path = Path(self.path_abs).resolve()
         if base_dir not in file_path.parents:
-            raise ValueError(
-                "File {} is not within the base directory.".format(file_path)
-            )
+            raise ValueError(f"File {file_path} is not within the base directory.")
 
     def send_file(self, etag: Optional[str] = None):
         """Send media file to client."""

--- a/gramps_webapi/api/file.py
+++ b/gramps_webapi/api/file.py
@@ -99,7 +99,7 @@ class LocalFileHandler(FileHandler):
                 "File {} is not within the base directory.".format(file_path)
             )
 
-    def send_file(self, etag=Optional[str]):
+    def send_file(self, etag: Optional[str] = None):
         """Send media file to client."""
         res = make_response(
             send_from_directory(self.base_dir, self.path_rel, mimetype=self.mime)

--- a/gramps_webapi/api/file.py
+++ b/gramps_webapi/api/file.py
@@ -33,7 +33,7 @@ from werkzeug.datastructures import FileStorage
 from gramps_webapi.const import MIME_JPEG
 from gramps_webapi.util import get_extension
 
-from .image import ThumbnailHandler
+from .image import LocalFileThumbnailHandler
 from .util import get_db_handle, get_media_base_dir
 
 
@@ -114,7 +114,7 @@ class LocalFileHandler(FileHandler):
             self._check_path()
         except ValueError:
             abort(403)
-        thumb = ThumbnailHandler(self.path_abs, self.mime)
+        thumb = LocalFileThumbnailHandler(self.path_abs, self.mime)
         buffer = thumb.get_cropped(x1=x1, y1=y1, x2=x2, y2=y2, square=square)
         return send_file(buffer, mimetype=MIME_JPEG)
 
@@ -124,7 +124,7 @@ class LocalFileHandler(FileHandler):
             self._check_path()
         except ValueError:
             abort(403)
-        thumb = ThumbnailHandler(self.path_abs, self.mime)
+        thumb = LocalFileThumbnailHandler(self.path_abs, self.mime)
         buffer = thumb.get_thumbnail(size=size, square=square)
         return send_file(buffer, mimetype=MIME_JPEG)
 
@@ -136,7 +136,7 @@ class LocalFileHandler(FileHandler):
             self._check_path()
         except ValueError:
             abort(403)
-        thumb = ThumbnailHandler(self.path_abs, self.mime)
+        thumb = LocalFileThumbnailHandler(self.path_abs, self.mime)
         buffer = thumb.get_thumbnail_cropped(
             size=size, x1=x1, y1=y1, x2=x2, y2=y2, square=square
         )

--- a/gramps_webapi/api/media.py
+++ b/gramps_webapi/api/media.py
@@ -1,0 +1,41 @@
+"""Generic media handler."""
+
+import os
+
+from flask import current_app
+
+from .file import FileHandler, LocalFileHandler
+from .s3 import ObjectStorageFileHandler
+
+
+class MediaHandler:
+    """Generic handler for media files."""
+
+    PREFIX_S3 = "s3://"
+
+    def __init__(self, base_dir: str):
+        """Initialize given a base dir or URL."""
+        self.base_dir = base_dir
+
+    def get_file_handler(self, handle) -> FileHandler:
+        """Get an appropriate file handler."""
+        if self.base_dir.startswith(self.PREFIX_S3):
+            return self._get_s3_file_handler(handle)
+        return self._get_local_file_handler(handle)
+
+    def _get_local_file_handler(self, handle) -> LocalFileHandler:
+        """Get a local file handler."""
+        return LocalFileHandler(handle, base_dir=self.base_dir)
+
+    def _get_s3_file_handler(self, handle) -> ObjectStorageFileHandler:
+        """Get an S3 file handler."""
+        if self.base_dir.startswith(self.PREFIX_S3):
+            bucket_name = self.base_dir[len(self.PREFIX_S3) :]
+        else:
+            raise ValueError(f"Invalid object storage URL: {self.base_dir}")
+        endpoint_url = current_app.config.get("AWS_ENDPOINT_URL") or os.getenv(
+            "AWS_ENDPOINT_URL"
+        )
+        return ObjectStorageFileHandler(
+            handle, bucket_name=bucket_name, endpoint_url=endpoint_url
+        )

--- a/gramps_webapi/api/media.py
+++ b/gramps_webapi/api/media.py
@@ -1,27 +1,31 @@
 """Generic media handler."""
 
 import os
+from typing import BinaryIO, Optional
 
 from flask import current_app
 
-from .file import FileHandler, LocalFileHandler
-from .s3 import ObjectStorageFileHandler
+from .file import FileHandler, LocalFileHandler, upload_file_local
+from .s3 import ObjectStorageFileHandler, upload_file_s3
 
 
 class MediaHandler:
     """Generic handler for media files."""
 
     PREFIX_S3 = "s3://"
+    TYPE_S3 = "s3"
+    TYPE_LOCAL = "local"
 
     def __init__(self, base_dir: str):
         """Initialize given a base dir or URL."""
         self.base_dir = base_dir
+        self.repo_type = self._get_repo_type()
 
-    def get_file_handler(self, handle) -> FileHandler:
-        """Get an appropriate file handler."""
+    def _get_repo_type(self) -> str:
+        """Get the type of repository."""
         if self.base_dir.startswith(self.PREFIX_S3):
-            return self._get_s3_file_handler(handle)
-        return self._get_local_file_handler(handle)
+            return self.TYPE_S3
+        return self.TYPE_LOCAL
 
     def _get_local_file_handler(self, handle) -> LocalFileHandler:
         """Get a local file handler."""
@@ -29,13 +33,38 @@ class MediaHandler:
 
     def _get_s3_file_handler(self, handle) -> ObjectStorageFileHandler:
         """Get an S3 file handler."""
+        bucket_name = self._get_s3_bucket_name()
+        endpoint_url = self._get_s3_endpoint_url()
+        return ObjectStorageFileHandler(
+            handle, bucket_name=bucket_name, endpoint_url=endpoint_url
+        )
+
+    def _get_s3_endpoint_url(self) -> Optional[str]:
+        """Get the endpoint URL (or None) in case of S3."""
+        return current_app.config.get("AWS_ENDPOINT_URL") or os.getenv(
+            "AWS_ENDPOINT_URL"
+        )
+
+    def _get_s3_bucket_name(self) -> str:
+        """Get the bucket name in case of S3."""
         if self.base_dir.startswith(self.PREFIX_S3):
             bucket_name = self.base_dir[len(self.PREFIX_S3) :]
         else:
             raise ValueError(f"Invalid object storage URL: {self.base_dir}")
-        endpoint_url = current_app.config.get("AWS_ENDPOINT_URL") or os.getenv(
-            "AWS_ENDPOINT_URL"
-        )
-        return ObjectStorageFileHandler(
-            handle, bucket_name=bucket_name, endpoint_url=endpoint_url
-        )
+        return bucket_name
+
+    def get_file_handler(self, handle) -> FileHandler:
+        """Get an appropriate file handler."""
+        if self.repo_type == self.TYPE_S3:
+            return self._get_s3_file_handler(handle)
+        return self._get_local_file_handler(handle)
+
+    def upload_file(self, stream: BinaryIO, checksum: str, mime: str) -> str:
+        """Upload a file from a stream, returning the relative file path."""
+        if self.repo_type == self.TYPE_S3:
+            bucket_name = self._get_s3_bucket_name()
+            endpoint_url = self._get_s3_endpoint_url()
+            return upload_file_s3(
+                bucket_name, stream, checksum, mime, endpoint_url=endpoint_url
+            )
+        return upload_file_local(self.base_dir, stream, checksum, mime)

--- a/gramps_webapi/api/media.py
+++ b/gramps_webapi/api/media.py
@@ -18,7 +18,7 @@ class MediaHandler:
 
     def __init__(self, base_dir: str):
         """Initialize given a base dir or URL."""
-        self.base_dir = base_dir
+        self.base_dir = base_dir or ""
         self.repo_type = self._get_repo_type()
 
     def _get_repo_type(self) -> str:

--- a/gramps_webapi/api/resources/file.py
+++ b/gramps_webapi/api/resources/file.py
@@ -29,7 +29,7 @@ from gramps.gen.errors import HandleError
 
 from ...auth.const import PERM_EDIT_OBJ
 from ..auth import require_permissions
-from ..file import process_file, upload_file
+from ..file import process_file
 from ..media import MediaHandler
 from ..util import get_db_handle
 from . import ProtectedResource
@@ -69,8 +69,8 @@ class MediaFileResource(ProtectedResource):
         if checksum == obj.checksum:
             # don't allow PUTting if the file didn't change
             abort(HTTPStatus.CONFLICT)
-        base_dir = current_app.config.get("MEDIA_BASE_DIR")
-        path = upload_file(base_dir, f, checksum, mime)
+        base_dir = current_app.config.get("MEDIA_BASE_DIR", "")
+        path = MediaHandler(base_dir).upload_file(f, checksum, mime)
         obj.set_checksum(checksum)
         obj.set_path(path)
         obj.set_mime_type(mime)

--- a/gramps_webapi/api/resources/file.py
+++ b/gramps_webapi/api/resources/file.py
@@ -29,7 +29,8 @@ from gramps.gen.errors import HandleError
 
 from ...auth.const import PERM_EDIT_OBJ
 from ..auth import require_permissions
-from ..file import LocalFileHandler, process_file, upload_file
+from ..file import process_file, upload_file
+from ..media import MediaHandler
 from ..util import get_db_handle
 from . import ProtectedResource
 from .util import transaction_to_json, update_object
@@ -45,8 +46,8 @@ class MediaFileResource(ProtectedResource):
             obj = db_handle.get_media_from_handle(handle)
         except HandleError:
             abort(HTTPStatus.NOT_FOUND)
-        base_dir = current_app.config.get("MEDIA_BASE_DIR")
-        handler = LocalFileHandler(handle, base_dir)
+        base_dir = current_app.config.get("MEDIA_BASE_DIR", "")
+        handler = MediaHandler(base_dir).get_file_handler(handle)
         return handler.send_file(etag=obj.checksum)
 
     def put(self, handle) -> Response:

--- a/gramps_webapi/api/resources/media.py
+++ b/gramps_webapi/api/resources/media.py
@@ -32,7 +32,8 @@ from gramps.gen.utils.grampslocale import GrampsLocale
 
 from ...auth.const import PERM_ADD_OBJ
 from ..auth import require_permissions
-from ..file import upload_file, process_file
+from ..file import process_file
+from ..media import MediaHandler
 from .base import (
     GrampsObjectProtectedResource,
     GrampsObjectResourceHelper,
@@ -78,8 +79,8 @@ class MediaObjectsResource(GrampsObjectsProtectedResource, MediaObjectResourceHe
         if not mime:
             abort(HTTPStatus.NOT_ACCEPTABLE)
         checksum, f = process_file(request.stream)
-        base_dir = current_app.config.get("MEDIA_BASE_DIR")
-        path = upload_file(base_dir, f, checksum, mime)
+        base_dir = current_app.config.get("MEDIA_BASE_DIR", "")
+        path = MediaHandler(base_dir).upload_file(f, checksum, mime)
         db_handle = self.db_handle_writable
         obj = Media()
         obj.set_checksum(checksum)

--- a/gramps_webapi/api/s3.py
+++ b/gramps_webapi/api/s3.py
@@ -1,0 +1,101 @@
+#
+# Gramps Web API - A RESTful API for the Gramps genealogy program
+#
+# Copyright (C) 2022      David Straub
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+"""Object storage (e.g. S3) handling utilities."""
+
+from typing import BinaryIO, Optional
+
+import boto3
+from botocore.exceptions import ClientError
+from flask import current_app, redirect, send_file
+
+from .file import FileHandler
+from .image import ThumbnailHandler
+from ..const import MIME_JPEG
+
+
+class ObjectStorageFileHandler(FileHandler):
+    """Handler for files on object storage (e.g. S3)."""
+
+    URL_LIFETIME = 3600
+
+    def __init__(self, handle, bucket_name: str, endpoint_url: Optional[str] = None):
+        """Initialize self given a handle and media base directory."""
+        super().__init__(handle)
+        self.bucket_name = bucket_name
+        self.client = boto3.client(
+            "s3",
+            endpoint_url=endpoint_url,
+            config=boto3.session.Config(
+                s3={"addressing_style": "path"}, signature_version="s3v4"
+            ),
+        )
+        self.object_name = self.checksum
+
+    def _get_presigned_url(self, expires_in: float):
+        """Get a presigned URL to a file object."""
+        try:
+            response = self.client.generate_presigned_url(
+                "get_object",
+                Params={
+                    "Bucket": self.bucket_name,
+                    "Key": self.object_name,
+                    "ResponseContentType": self.mime,
+                },
+                ExpiresIn=expires_in,
+            )
+        except ClientError as err:
+            current_app.logger.error(err)
+            return None
+        return response
+
+    def _download_fileobj(self) -> BinaryIO:
+        current_app.logger.error(f"s3://{self.bucket_name}/{self.object_name}")
+        response = self.client.get_object(Bucket=self.bucket_name, Key=self.object_name)
+        return response["Body"]
+
+    def send_file(self, etag: Optional[str] = None):
+        """Send media file to client."""
+        url = self._get_presigned_url(expires_in=self.URL_LIFETIME)
+        return redirect(url, 307)
+
+    def send_cropped(self, x1: int, y1: int, x2: int, y2: int, square: bool = False):
+        """Send cropped image."""
+        fileobj = self._download_fileobj()
+        thumb = ThumbnailHandler(fileobj, self.mime)
+        buffer = thumb.get_cropped(x1=x1, y1=y1, x2=x2, y2=y2, square=square)
+        return send_file(buffer, mimetype=MIME_JPEG)
+
+    def send_thumbnail(self, size: int, square: bool = False):
+        """Send thumbnail of image."""
+        fileobj = self._download_fileobj()
+        thumb = ThumbnailHandler(fileobj, self.mime)
+        buffer = thumb.get_thumbnail(size=size, square=square)
+        return send_file(buffer, mimetype=MIME_JPEG)
+
+    def send_thumbnail_cropped(
+        self, size: int, x1: int, y1: int, x2: int, y2: int, square: bool = False
+    ):
+        """Send thumbnail of cropped image."""
+        fileobj = self._download_fileobj()
+        thumb = ThumbnailHandler(fileobj, self.mime)
+        buffer = thumb.get_thumbnail_cropped(
+            size=size, x1=x1, y1=y1, x2=x2, y2=y2, square=square
+        )
+        return send_file(buffer, mimetype=MIME_JPEG)

--- a/gramps_webapi/app.py
+++ b/gramps_webapi/app.py
@@ -103,9 +103,7 @@ def create_app(db_manager=None):
     if app.config.get("CORS_ORIGINS"):
         CORS(
             app,
-            resources={
-                "{}/*".format(API_PREFIX): {"origins": app.config["CORS_ORIGINS"]}
-            },
+            resources={f"{API_PREFIX}/*": {"origins": app.config["CORS_ORIGINS"]}},
         )
 
     # enable gzip compression

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ REQUIREMENTS = [
     "whoosh",
     "jsonschema",
     "ffmpeg-python",
+    "boto3",
 ]
 
 setup(


### PR DESCRIPTION
This PR implements storing media files on S3 or a compatible object storage service. It supports completely replacing file-based storage with S3 for original files, thumbnails, and for adding/uploading new media files.

It requires the following configuration:

- environment variables `AWS_SECRET_KEY_ID` and `AWS_SECRET_ACCESS_KEY` for S3 credentials
- optional environment variable `AWS_ENDPOINT_URL` when using a service other than AWS S3
- setting the `MEDIA_BASE_DIR` configuration option to `s3://my-bucket-name`

To test this implementation, you can do the following:

- install the `S3MediaUploader` add-on from this PR https://github.com/gramps-project/addons-source/pull/526 and follow the instructions there to upload your media to a local S3-like server (S3 Ninja)
- Use `s3://testbucket1` for `MEDIA_BASE_DIR` and set the `AWS_ENDPOINT_URL` environment variable to `http://localhost:9444`