### PR TITLE
Implement missing media file list and upload to enable file sync

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip wheel
           pip install pycairo PyGObject pytest PyYAML jsonschema pyICU
-          python -m pip install git+https://github.com/Nick-Hall/gramps@tests#egg=gramps
+          python -m pip install git+https://github.com/gramps-project/gramps#egg=gramps
           pip install .
           pip list
       - name: Test with pytest

--- a/gramps_webapi/api/media.py
+++ b/gramps_webapi/api/media.py
@@ -1,12 +1,17 @@
 """Generic media handler."""
 
 import os
-from typing import BinaryIO, Optional
+from pathlib import Path
+from typing import BinaryIO, List, Optional
 
 from flask import current_app
+from gramps.gen.lib import Media
 
+from ..types import FilenameOrPath
+from ..util import get_extension
 from .file import FileHandler, LocalFileHandler, upload_file_local
-from .s3 import ObjectStorageFileHandler, upload_file_s3
+from .s3 import ObjectStorageFileHandler, filter_existing_files_s3, upload_file_s3
+from .util import get_media_base_dir
 
 
 class MediaHandler:
@@ -59,12 +64,53 @@ class MediaHandler:
             return self._get_s3_file_handler(handle)
         return self._get_local_file_handler(handle)
 
-    def upload_file(self, stream: BinaryIO, checksum: str, mime: str) -> str:
-        """Upload a file from a stream, returning the relative file path."""
+    @staticmethod
+    def get_default_filename(checksum: str, mime: str) -> str:
+        """Get the default file name for given checksum and MIME type."""
+        if not mime:
+            raise ValueError("Missing MIME type")
+        ext = get_extension(mime)
+        if not ext:
+            raise ValueError("MIME type not recognized")
+        return f"{checksum}{ext}"
+
+    def upload_file(
+        self,
+        stream: BinaryIO,
+        checksum: str,
+        mime: str,
+        path: Optional[FilenameOrPath] = None,
+    ) -> None:
+        """Upload a file from a stream."""
         if self.repo_type == self.TYPE_S3:
             bucket_name = self._get_s3_bucket_name()
             endpoint_url = self._get_s3_endpoint_url()
-            return upload_file_s3(
+            upload_file_s3(
                 bucket_name, stream, checksum, mime, endpoint_url=endpoint_url
             )
-        return upload_file_local(self.base_dir, stream, checksum, mime)
+        base_dir = self.base_dir or get_media_base_dir()
+        if path is not None:
+            if Path(path).is_absolute():
+                # Don't allow absolute paths! This will raise
+                # if path is not relative to base_dir
+                rel_path: FilenameOrPath = Path(path).relative_to(base_dir)
+            else:
+                rel_path = path
+            upload_file_local(base_dir, rel_path, stream)
+        else:
+            rel_path = self.get_default_filename(checksum, mime)
+            upload_file_local(base_dir, rel_path, stream)
+
+    def filter_existing_files(self, objects: List[Media]) -> List[Media]:
+        """Given a list of media objects, return the ones with existing files."""
+        if self.repo_type == self.TYPE_S3:
+            # for S3, we use the bucket-level list of handles to avoid having
+            # to do many GETs that are more expensive than one LIST
+            bucket_name = self._get_s3_bucket_name()
+            endpoint_url = self._get_s3_endpoint_url()
+            return filter_existing_files_s3(
+                bucket_name, objects, endpoint_url=endpoint_url
+            )
+        return [
+            obj for obj in objects if self.get_file_handler(obj.handle).file_exists()
+        ]

--- a/gramps_webapi/api/resources/base.py
+++ b/gramps_webapi/api/resources/base.py
@@ -48,6 +48,7 @@ from .util import (
     fix_object_dict,
     get_backlinks,
     get_extended_attributes,
+    get_missing_media_file_handles,
     get_reference_profile_for_object,
     get_soundex,
     hash_object,
@@ -350,6 +351,7 @@ class GrampsObjectsResource(GrampsObjectResourceHelper, Resource):
             "sort": fields.DelimitedList(fields.Str(validate=validate.Length(min=1))),
             "soundex": fields.Boolean(missing=False),
             "strip": fields.Boolean(missing=False),
+            "filemissing": fields.Boolean(missing=False),
         },
         location="query",
     )
@@ -374,6 +376,9 @@ class GrampsObjectsResource(GrampsObjectResourceHelper, Resource):
             handles = apply_filter(
                 self.db_handle, args, self.gramps_class_name, handles
             )
+
+        if self.gramps_class_name == "Media" and args.get("filemissing"):
+            handles = get_missing_media_file_handles(self.db_handle, handles)
 
         if args["dates"]:
             handles = self.match_dates(handles, args["dates"])

--- a/gramps_webapi/api/resources/media.py
+++ b/gramps_webapi/api/resources/media.py
@@ -80,7 +80,9 @@ class MediaObjectsResource(GrampsObjectsProtectedResource, MediaObjectResourceHe
             abort(HTTPStatus.NOT_ACCEPTABLE)
         checksum, f = process_file(request.stream)
         base_dir = current_app.config.get("MEDIA_BASE_DIR", "")
-        path = MediaHandler(base_dir).upload_file(f, checksum, mime)
+        media_handler = MediaHandler(base_dir)
+        media_handler.upload_file(f, checksum, mime)
+        path = media_handler.get_default_filename(checksum, mime)
         db_handle = self.db_handle_writable
         obj = Media()
         obj.set_checksum(checksum)

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -3213,6 +3213,11 @@ paths:
             ------ | --------
             all | Returns all information
             references | Returns information about objects that refer to the place
+      - name: filemissing
+        in: query
+        required: false
+        type: boolean
+        description: If present, only return media objects where the file is not available to the server.
       responses:
         200:
           description: "OK: Successful operation."
@@ -3409,6 +3414,13 @@ paths:
       operationId: updateFile
       security:
         - Bearer: []
+      parameters:
+      - name: uploadmissing
+        in: query
+        required: false
+        type: boolean
+        default: false
+        description: "To be set to true when uploading a missing file to an existing media object. Will not modify the object."
       responses:
         200:
           description: "OK. Successful operation."
@@ -3420,6 +3432,8 @@ paths:
           description: "Bad Request: Malformed request could not be parsed."
         401:
           description: "Unauthorized: Missing authorization header."
+        409:
+          description: "Conflict: Uploaded file identical to existing file or has wrong checksum for missing file."
         422:
           description: "Unprocessable Entity: Invalid or bad parameter provided."
 

--- a/tests/test_endpoints/test_families.py
+++ b/tests/test_endpoints/test_families.py
@@ -457,7 +457,7 @@ class TestFamilies(unittest.TestCase):
                         "summary": "Birth - , أحمد",
                     },
                     "death": {
-                        "age": "77 years, 11 days",
+                        "age": "74 years, 8 months, 26 days",
                         "citations": 0,
                         "confidence": 0,
                         "date": "241-03-12 (Islamic)",
@@ -851,7 +851,7 @@ class TestFamiliesHandle(unittest.TestCase):
                     "place": "Farmington, MO, USA",
                     "span": "0 days",
                     "type": "Marriage",
-                    'summary': 'Marriage - Garner, Gerard Stephen and George, Elizabeth'
+                    "summary": "Marriage - Garner, Gerard Stephen and George, Elizabeth",
                 },
                 "mother": {
                     "birth": {

--- a/tests/test_endpoints/test_people.py
+++ b/tests/test_endpoints/test_people.py
@@ -842,7 +842,7 @@ class TestPeople(unittest.TestCase):
         self.assertEqual(rv[0]["profile"]["birth"]["age"], "0 Tage")
         self.assertEqual(rv[0]["profile"]["birth"]["type"], "Geburt")
         self.assertEqual(rv[0]["profile"]["families"][0]["relationship"], "Verheiratet")
-        self.assertEqual(rv[0]["profile"]["events"][2]["type"], "Hochzeit")
+        self.assertEqual(rv[0]["profile"]["events"][2]["type"], "Heirat")
 
     def test_get_people_parameter_backlinks_validate_semantics(self):
         """Test invalid backlinks parameter and values."""

--- a/tests/test_endpoints/test_timelines.py
+++ b/tests/test_endpoints/test_timelines.py
@@ -166,7 +166,7 @@ class TestTimelinesPeople(unittest.TestCase):
     def test_get_timelines_people_parameter_locale_expected_result(self):
         """Test expected profile response for a locale."""
         rv = check_success(self, TEST_URL + "people/?page=1&locale=de")
-        self.assertEqual(rv[0]["label"], "Hochzeit")
+        self.assertEqual(rv[0]["label"], "Heirat")
         self.assertEqual(rv[0]["person"]["birth"]["type"], "Geburt")
         self.assertEqual(rv[0]["person"]["death"]["type"], "Tod")
 
@@ -430,7 +430,7 @@ class TestTimelinesFamilies(unittest.TestCase):
     def test_get_timelines_families_parameter_locale_expected_result(self):
         """Test expected profile response for a locale."""
         rv = check_success(self, TEST_URL + "families/?page=1&locale=de")
-        self.assertEqual(rv[0]["label"], "Hochzeit")
+        self.assertEqual(rv[0]["label"], "Heirat")
         self.assertEqual(rv[0]["person"]["birth"]["type"], "Geburt")
         self.assertEqual(rv[0]["person"]["death"]["type"], "Tod")
         self.assertEqual(rv[0]["place"]["type"], "Stadt")


### PR DESCRIPTION
This PR implements two features that are necessary to enable a synchronization of media files between Gramps Desktop and Gramps Web regardless of using local media files or cloud media files on S3:

- The GET endpoint `/media/` gets a new boolean query parameter `filemissing`. When it is true, only media objects are listed where the corresponding file is not found on the server (local media base directory or remote S3 bucket). This allows fetching a list of missing files and checksum.
- The PUT endpoint `/media/<handle>/file` gets a new boolean query parameter `uploadmissing`. When it is true, the uploaded file is only accepted if 1) is has the same checksum as the media object and 2) the file is not yet present on the server. In contrast to the behaviour without this flag, the media object itself is not modified (as the file did not change).

With these two features, files can be synchronized with the following workflow:

1. Synchronize databases
2. Get list of locally missing files
3. Get list of remotely missing files using `/media/?filemissing=1`
4. Download locally missing files using GET `/media/<handle>/file`
5. Upload remotely missing files using PUT `/media/<handle>/file?uploadmissing=1`