### PR TITLE
Fix relationship translation

### DIFF
--- a/gramps_webapi/api/resources/relations.py
+++ b/gramps_webapi/api/resources/relations.py
@@ -58,7 +58,9 @@ class RelationResource(ProtectedResource, GrampsJSONEncoder):
         calc = get_relationship_calculator(reinit=True, clocale=locale)
         calc.set_depth(args["depth"])
 
-        data = calc.get_one_relationship(db_handle, person1, person2, extra_info=True)
+        data = calc.get_one_relationship(
+            db_handle, person1, person2, extra_info=True, olocale=locale
+        )
         return self.response(
             200,
             {

--- a/tests/test_endpoints/test_relations.py
+++ b/tests/test_endpoints/test_relations.py
@@ -104,6 +104,15 @@ class TestRelations(unittest.TestCase):
         )
         self.assertEqual(rv["relationship_string"], "Stief-/Adoptivalttante")
 
+    def test_get_relations_parameter_locale_expected_result_partner(self):
+        """Test locale parameter working as expected."""
+        rv = check_success(self, TEST_URL + "cc8205d87831c772e87/cc8205d872f532ab14e")
+        self.assertEqual(rv["relationship_string"], "husband")
+        rv = check_success(
+            self, TEST_URL + "cc8205d87831c772e87/cc8205d872f532ab14e?locale=it"
+        )
+        self.assertEqual(rv["relationship_string"], "marito")
+
 
 class TestRelationsAll(unittest.TestCase):
     """Test cases for the /api/relations/{handle1}/{handle2}/all endpoint."""


### PR DESCRIPTION
I noticed that the output of the `/relations/` endpoint was sometimes not translated and found this is due to a missing locale parameter being passed in one method which is only needed for some translations; e.g. the stepgrandaunt example in the unit tests was translated, but "husband" wasn't. This PR fixes this issue and adds 1 unit test.