### PR TITLE
Do not expire refresh tokens by default

### DIFF
--- a/gramps_webapi/config.py
+++ b/gramps_webapi/config.py
@@ -51,4 +51,4 @@ class DefaultConfigJWT(object):
 
     JWT_TOKEN_LOCATION = ["headers", "query_string"]
     JWT_ACCESS_TOKEN_EXPIRES = datetime.timedelta(minutes=15)
-    JWT_REFRESH_TOKEN_EXPIRES = datetime.timedelta(days=30)
+    JWT_REFRESH_TOKEN_EXPIRES = False


### PR DESCRIPTION
This PR suggest a simple change: changing the default configuration value for the refresh token expiry time from 30 days to infinity, i.e. refresh tokens never expire.

While 30 days is the default value in `flask-jwt-extended`, it is annoying in practice that, every 30 days, I am just logged out from my Gramps Web instance without warning, see https://github.com/gramps-project/Gramps.js/issues/71. But there is no way around it; a refresh token cannot be issued without asking for the password, because that would defeat its whole purpose.

So the question is, does expiring the refresh token after 30 days add any security? I think it doesn't. If a refresh token is stolen, 30 days are more than enough time to do harm.

And in all other web services we use, we are not logged out on a seemingly random basis.

Finally, since this is just a configuration option, any user who thinks it is not a good idea can change it back to a finite time.