### PR TITLE
Add face detection endpoint (fixes #286)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,11 +19,11 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Ubuntu dependencies
-        run: sudo apt-get -y install gettext appstream pkg-config libcairo2-dev gir1.2-gtk-3.0 libgirepository1.0-dev libicu-dev python3-opencv
+        run: sudo apt-get -y install gettext appstream pkg-config libcairo2-dev gir1.2-gtk-3.0 libgirepository1.0-dev libicu-dev
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip wheel
-          pip install pycairo PyGObject pytest PyYAML jsonschema pyICU
+          pip install pycairo PyGObject pytest PyYAML jsonschema pyICU opencv-python
           python -m pip install git+https://github.com/gramps-project/gramps#egg=gramps
           pip install .
           pip list

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Ubuntu dependencies
-        run: sudo apt-get -y install gettext appstream pkg-config libcairo2-dev gir1.2-gtk-3.0 libgirepository1.0-dev libicu-dev
+        run: sudo apt-get -y install gettext appstream pkg-config libcairo2-dev gir1.2-gtk-3.0 libgirepository1.0-dev libicu-dev python3-opencv
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip wheel

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && apt-get install -y \
   poppler-utils ffmpeg libavcodec-extra \
   unzip \
   libpq-dev postgresql-client postgresql-client-common python3-psycopg2 \
+  python3-opencv \
   && rm -rf /var/lib/apt/lists/*
 
 # set locale

--- a/gramps_webapi/api/__init__.py
+++ b/gramps_webapi/api/__init__.py
@@ -22,11 +22,11 @@
 from typing import Type
 
 from flask import Blueprint, current_app
-from flask_caching import Cache
 from webargs import fields, validate
 
 from ..const import API_PREFIX
 from .auth import jwt_required_ifauth
+from .cache import thumbnail_cache
 from .media import MediaHandler
 from .resources.base import Resource
 from .resources.bookmarks import BookmarkResource, BookmarksResource
@@ -37,6 +37,7 @@ from .resources.exporters import (
     ExporterResource,
     ExportersResource,
 )
+from .resources.face_detection import MediaFaceDetectionResource
 from .resources.facts import FactsResource
 from .resources.families import FamiliesResource, FamilyResource
 from .resources.file import MediaFileResource
@@ -86,7 +87,6 @@ from .resources.transactions import TransactionsResource
 from .util import make_cache_key_thumbnails, use_args
 
 api_blueprint = Blueprint("api", __name__, url_prefix=API_PREFIX)
-thumbnail_cache = Cache()
 
 
 def register_endpt(resource: Type[Resource], url: str, name: str):
@@ -244,10 +244,18 @@ register_endpt(
 # Search
 register_endpt(SearchResource, "/search/", "search")
 
+# Media files
 register_endpt(
     MediaFileResource,
     "/media/<string:handle>/file",
     "media_file",
+)
+
+# Face detection
+register_endpt(
+    MediaFaceDetectionResource,
+    "/media/<string:handle>/face_detection",
+    "media_face_detection",
 )
 
 

--- a/gramps_webapi/api/cache.py
+++ b/gramps_webapi/api/cache.py
@@ -1,0 +1,5 @@
+"""Caching functions."""
+
+from flask_caching import Cache
+
+thumbnail_cache = Cache()

--- a/gramps_webapi/api/file.py
+++ b/gramps_webapi/api/file.py
@@ -84,12 +84,15 @@ class FileHandler:
 
     def get_face_regions(self, etag: Optional[str] = None):
         """Return regions containing faces."""
-        fobj = self.get_file_object()
-        try:
-            regions = detect_faces(fobj)
-        except ImportError:
-            # numpy or opencv missing
-            abort(501)
+        if self.mime.startswith("image"):
+            fobj = self.get_file_object()
+            try:
+                regions = detect_faces(fobj)
+            except ImportError:
+                # numpy or opencv missing
+                abort(501)
+        else:
+            regions = []
         res = make_response(jsonify(regions))
         if etag:
             res.headers["ETag"] = etag

--- a/gramps_webapi/api/image.py
+++ b/gramps_webapi/api/image.py
@@ -25,7 +25,7 @@ import shutil
 import os
 import tempfile
 from pathlib import Path
-from typing import BinaryIO, Callable
+from typing import BinaryIO, Callable, List, Tuple
 
 import ffmpeg
 from pdf2image import convert_from_path
@@ -207,5 +207,32 @@ class LocalFileThumbnailHandler(ThumbnailHandler):
     def __init__(self, path: FilenameOrPath, mime_type: str) -> None:
         """Initialize self given a path and MIME type."""
         self.path = Path(path)
-        stream = open(self.path, "rb")
+        with open(self.path, "rb") as f:
+            stream = io.BytesIO(f.read())
         super().__init__(stream=stream, mime_type=mime_type)
+
+
+def detect_faces(stream: BinaryIO) -> List[Tuple[float, float, float, float]]:
+    """Detect faces in an image (stream)."""
+    import cv2
+    import numpy as np
+
+    file_bytes = np.asarray(bytearray(stream.read()), dtype=np.uint8)
+    cv_image = cv2.imdecode(file_bytes, cv2.IMREAD_COLOR)
+    # img_size = (cv_image.shape[0], cv_image.shape[1])
+    cv_image = cv2.cvtColor(cv_image, cv2.COLOR_BGR2GRAY)
+    haarcascade_path = os.path.join(
+        cv2.data.haarcascades, "haarcascade_frontalface_default.xml"
+    )
+    cascade = cv2.CascadeClassifier(haarcascade_path)
+    faces = cascade.detectMultiScale(cv_image, 1.1, 4)
+    height, width = cv_image.shape
+    return [
+        (
+            100 * x / width,
+            100 * y / height,
+            100 * (x + w) / width,
+            100 * (y + h) / height,
+        )
+        for (x, y, w, h) in faces
+    ]

--- a/gramps_webapi/api/image.py
+++ b/gramps_webapi/api/image.py
@@ -219,7 +219,6 @@ def detect_faces(stream: BinaryIO) -> List[Tuple[float, float, float, float]]:
 
     file_bytes = np.asarray(bytearray(stream.read()), dtype=np.uint8)
     cv_image = cv2.imdecode(file_bytes, cv2.IMREAD_COLOR)
-    # img_size = (cv_image.shape[0], cv_image.shape[1])
     cv_image = cv2.cvtColor(cv_image, cv2.COLOR_BGR2GRAY)
     haarcascade_path = os.path.join(
         cv2.data.haarcascades, "haarcascade_frontalface_default.xml"

--- a/gramps_webapi/api/resources/face_detection.py
+++ b/gramps_webapi/api/resources/face_detection.py
@@ -1,0 +1,47 @@
+#
+# Gramps Web API - A RESTful API for the Gramps genealogy program
+#
+# Copyright (C) 2022      David Straub
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+"""Face detection API resource."""
+
+
+from http import HTTPStatus
+
+from flask import Response, abort, current_app
+from gramps.gen.errors import HandleError
+
+from ..cache import thumbnail_cache
+from ..media import MediaHandler
+from ..util import get_db_handle, make_cache_key_thumbnails
+from . import ProtectedResource
+
+
+class MediaFaceDetectionResource(ProtectedResource):
+    """Resource for face detection in media files."""
+
+    @thumbnail_cache.cached(make_cache_key=make_cache_key_thumbnails)
+    def get(self, handle) -> Response:
+        """Get detected face regions."""
+        db_handle = get_db_handle()
+        try:
+            obj = db_handle.get_media_from_handle(handle)
+        except HandleError:
+            abort(HTTPStatus.NOT_FOUND)
+        base_dir = current_app.config.get("MEDIA_BASE_DIR", "")
+        handler = MediaHandler(base_dir).get_file_handler(handle)
+        return handler.get_face_regions(etag=obj.checksum)

--- a/gramps_webapi/api/s3.py
+++ b/gramps_webapi/api/s3.py
@@ -78,6 +78,10 @@ class ObjectStorageFileHandler(FileHandler):
         response = self.client.get_object(Bucket=self.bucket_name, Key=self.object_name)
         return response["Body"]
 
+    def get_file_object(self) -> BinaryIO:
+        """Return a binary file object."""
+        return self._download_fileobj()
+
     def file_exists(self) -> bool:
         """Check if the file exists."""
         try:

--- a/gramps_webapi/app.py
+++ b/gramps_webapi/app.py
@@ -27,7 +27,8 @@ from flask_compress import Compress
 from flask_cors import CORS
 from flask_jwt_extended import JWTManager
 
-from .api import api_blueprint, thumbnail_cache
+from .api import api_blueprint
+from .api.cache import thumbnail_cache
 from .api.resources.token import limiter
 from .api.search import SearchIndexer
 from .auth import SQLAuth

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -3438,6 +3438,38 @@ paths:
           description: "Unprocessable Entity: Invalid or bad parameter provided."
 
 
+  /media/{handle}/face_detection:
+    parameters:
+    - name: handle
+      in: path
+      required: true
+      type: string
+      minLength: 8
+      description: "The unique identifier for a media item."
+    get:
+      tags:
+      - media
+      summary: "Detect faces in an image."
+      operationId: getMediaItemFaces
+      security:
+        - Bearer: []
+      responses:
+        200:
+          description: "OK: Successful operation."
+          schema:
+            type: array
+            items:
+              type: array
+              items:
+                type: number
+              example: [10, 20, 30, 40]
+        401:
+          description: "Unauthorized: Missing authorization header."
+        404:
+          description: "Not Found: Media item not found."
+        501:
+          description: "Not Implemented: Server does not support face detection."
+
   /media/{handle}/thumbnail/{size}:
     get:
       tags:

--- a/tests/test_endpoints/test_file.py
+++ b/tests/test_endpoints/test_file.py
@@ -239,3 +239,33 @@ class TestCroppedThumbnail(unittest.TestCase):
             thumb = Image.open(BytesIO(rv.data))
             assert thumb.width == thumb.height
             assert min(full_img.width, full_img.height) == thumb.height
+
+
+class TestFaceDetection(unittest.TestCase):
+    """Test cases for the /api/media/{}/face_detection endpoint."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Test class setup."""
+        cls.client = get_test_client()
+
+    def test_get_faces_requires_token(self):
+        """Test authorization required."""
+        check_requires_token(self, TEST_URL + "b39fe1cfc1305ac4a21/face_detection")
+
+    def test_get_faces(self):
+        """Test reponse for face detection."""
+        rv = check_success(
+            self,
+            f"{TEST_URL}F8JYGQFL2PKLSYH79X/face_detection",
+            full=True,
+        )
+        faces = rv.json
+        assert len(faces) == 1
+        x1, y1, x2, y2 = faces[0]
+        assert 20 < x1 < 70
+        assert 50 < x2 < 80
+        assert 0 < y1 < 20
+        assert 20 < y2 < 60
+        assert x2 > x1
+        assert y2 > y1


### PR DESCRIPTION
This uses opencv for face detection and adds an endpoint `/api/media/{handle}/face_detection` returning a list of rectangles.

To do
- [x] better error handling
- [x] update docker images.