### PR TITLE
Implement import endpoint (fixes #287)

### DIFF
--- a/gramps_webapi/api/__init__.py
+++ b/gramps_webapi/api/__init__.py
@@ -42,6 +42,11 @@ from .resources.families import FamiliesResource, FamilyResource
 from .resources.file import MediaFileResource
 from .resources.filters import FilterResource, FiltersResource, FiltersResources
 from .resources.holidays import HolidayResource, HolidaysResource
+from .resources.importers import (
+    ImporterFileResource,
+    ImporterResource,
+    ImportersResource,
+)
 from .resources.living import LivingDatesResource, LivingResource
 from .resources.media import MediaObjectResource, MediaObjectsResource
 from .resources.metadata import MetadataResource
@@ -196,6 +201,12 @@ register_endpt(
 )
 register_endpt(ExporterResource, "/exporters/<string:extension>", "exporter")
 register_endpt(ExportersResource, "/exporters/", "exporters")
+# Importers
+register_endpt(
+    ImporterFileResource, "/importers/<string:extension>/file", "importer-file"
+)
+register_endpt(ImporterResource, "/importers/<string:extension>", "importer")
+register_endpt(ImportersResource, "/importers/", "importers")
 # Holidays
 register_endpt(
     HolidayResource,

--- a/gramps_webapi/api/resources/importers.py
+++ b/gramps_webapi/api/resources/importers.py
@@ -55,12 +55,18 @@ from .emit import GrampsJSONEncoder
 _ = glocale.translation.gettext
 
 
+# list of importers (by file extension) that are not allowed
+DISABLED_IMPORTERS = ["grdb"]
+
+
 def get_importers(extension: str = None):
     """Extract and return list of importers."""
     importers = []
     plugin_manager = BasePluginManager.get_instance()
     for plugin in plugin_manager.get_import_plugins():
         if extension is not None and extension != plugin.get_extension():
+            continue
+        if extension in DISABLED_IMPORTERS:
             continue
         importer = {
             "name": plugin.get_name(),

--- a/gramps_webapi/api/resources/importers.py
+++ b/gramps_webapi/api/resources/importers.py
@@ -1,0 +1,132 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2007-2008 Donald N. Allingham
+# Copyright (C) 2008      Gary Burton
+# Copyright (C) 2008      Robert Cheramy <robert@cheramy.net>
+# Copyright (C) 2020      Christopher Horn
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Importers Plugin API resource."""
+
+import os
+import shutil
+import tempfile
+import uuid
+from http import HTTPStatus
+from typing import Any, IO, Dict
+
+from flask import Response, abort, current_app, request, send_file
+from gramps.gen.const import GRAMPS_LOCALE as glocale
+from gramps.gen.db.base import DbReadBase
+from gramps.gen.errors import HandleError
+from gramps.gen.plug import BasePluginManager
+from gramps.gen.proxy import (
+    FilterProxyDb,
+    LivingProxyDb,
+    PrivateProxyDb,
+    ReferencedBySelectionProxyDb,
+)
+from gramps.gen.user import User
+from gramps.gen.utils.resourcepath import ResourcePath
+from webargs import fields, validate
+
+from ...auth.const import PERM_IMPORT_FILE
+from ..auth import require_permissions
+from ..file import process_file
+from ..util import get_buffer_for_file, get_db_handle, get_locale_for_language, use_args
+from . import ProtectedResource
+from .emit import GrampsJSONEncoder
+
+_ = glocale.translation.gettext
+
+
+def get_importers(extension: str = None):
+    """Extract and return list of importers."""
+    importers = []
+    plugin_manager = BasePluginManager.get_instance()
+    for plugin in plugin_manager.get_import_plugins():
+        if extension is not None and extension != plugin.get_extension():
+            continue
+        importer = {
+            "name": plugin.get_name(),
+            "description": plugin.get_description(),
+            "extension": plugin.get_extension(),
+            "module": plugin.get_module_name(),
+        }
+        importers.append(importer)
+    return importers
+
+
+def run_import(db_handle: DbReadBase, file_obj: IO[bytes], extension: str) -> None:
+    """Generate the import."""
+    tmp_dir = tempfile.gettempdir()
+    file_name = os.path.join(tmp_dir, f"{uuid.uuid4()}.{extension}")
+    plugin_manager = BasePluginManager.get_instance()
+    for plugin in plugin_manager.get_import_plugins():
+        if extension == plugin.get_extension():
+            import_function = plugin.get_import_function()
+            with open(file_name, "wb") as f:
+                f.write(file_obj.read())
+            result = import_function(db_handle, file_name, User())
+            os.remove(file_name)
+            if not result:
+                abort(500)
+            return
+
+
+class ImportersResource(ProtectedResource, GrampsJSONEncoder):
+    """Importers resource."""
+
+    @use_args({}, location="query")
+    def get(self, args: Dict[str, Any]) -> Response:
+        """Get all available importer attributes."""
+        get_db_handle()
+        return self.response(200, get_importers())
+
+
+class ImporterResource(ProtectedResource, GrampsJSONEncoder):
+    """Import resource."""
+
+    @use_args({}, location="query")
+    def get(self, args: Dict[str, Any], extension: str) -> Response:
+        """Get specific report attributes."""
+        get_db_handle()
+        importers = get_importers(extension)
+        if not importers:
+            abort(404)
+        return self.response(200, importers[0])
+
+
+class ImporterFileResource(ProtectedResource):
+    """Import file resource."""
+
+    @use_args(
+        {
+            "jwt": fields.String(required=False),
+        },
+        location="query",
+    )
+    def post(self, args: Dict, extension: str) -> Response:
+        """Import file."""
+        require_permissions([PERM_IMPORT_FILE])
+        db_handle = get_db_handle()
+        importers = get_importers(extension)
+        if not importers:
+            abort(HTTPStatus.NOT_FOUND)
+        run_import(db_handle, request.stream, extension)
+        return Response(status=201)

--- a/gramps_webapi/auth/const.py
+++ b/gramps_webapi/auth/const.py
@@ -40,6 +40,7 @@ PERM_VIEW_PRIVATE = "ViewPrivate"
 PERM_EDIT_OBJ = "EditObject"
 PERM_ADD_OBJ = "AddObject"
 PERM_DEL_OBJ = "DeleteObject"
+PERM_IMPORT_FILE = "ImportFile"
 
 PERMISSIONS = {
     ROLE_OWNER: {
@@ -53,6 +54,7 @@ PERMISSIONS = {
         PERM_EDIT_OBJ,
         PERM_ADD_OBJ,
         PERM_DEL_OBJ,
+        PERM_IMPORT_FILE,
     },
     ROLE_EDITOR: {
         PERM_EDIT_OWN_USER,
@@ -61,9 +63,18 @@ PERMISSIONS = {
         PERM_ADD_OBJ,
         PERM_DEL_OBJ,
     },
-    ROLE_CONTRIBUTOR: {PERM_EDIT_OWN_USER, PERM_VIEW_PRIVATE, PERM_ADD_OBJ,},
-    ROLE_MEMBER: {PERM_EDIT_OWN_USER, PERM_VIEW_PRIVATE,},
-    ROLE_GUEST: {PERM_EDIT_OWN_USER,},
+    ROLE_CONTRIBUTOR: {
+        PERM_EDIT_OWN_USER,
+        PERM_VIEW_PRIVATE,
+        PERM_ADD_OBJ,
+    },
+    ROLE_MEMBER: {
+        PERM_EDIT_OWN_USER,
+        PERM_VIEW_PRIVATE,
+    },
+    ROLE_GUEST: {
+        PERM_EDIT_OWN_USER,
+    },
 }
 
 # keys/values for user claims

--- a/gramps_webapi/const.py
+++ b/gramps_webapi/const.py
@@ -36,6 +36,9 @@ TEST_EXAMPLE_GRAMPS_CONFIG = resource_filename(
 TEST_EXAMPLE_GRAMPS_AUTH_CONFIG = resource_filename(
     "gramps_webapi", "data/example_gramps_auth.cfg"
 )
+TEST_EMPTY_GRAMPS_AUTH_CONFIG = resource_filename(
+    "gramps_webapi", "data/empty_gramps_auth.cfg"
+)
 
 # environment variables
 ENV_CONFIG_FILE = "GRAMPS_API_CONFIG"

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -5787,6 +5787,82 @@ paths:
 
 
 ##############################################################################
+# Endpoint - Importers
+##############################################################################
+
+  /importers:
+    get:
+      tags:
+      - importers
+      summary: "Get all importers."
+      operationId: getAllImporters
+      security:
+        - Bearer: []
+      responses:
+        200:
+          description: "OK: Successful operation."
+          schema:
+            type: array
+            items:
+              $ref: "#/definitions/Importer"
+        401:
+          description: "Unauthorized: Missing authorization header."
+        422:
+          description: "Unprocessable Entity: Invalid or bad parameter provided."
+
+
+  /importers/{extension}:
+    get:
+      tags:
+      - importers
+      summary: "Get a specific importer."
+      operationId: getImporter
+      security:
+        - Bearer: []
+      parameters:
+      - name: extension
+        in: path
+        required: true
+        type: string
+        description: "The file extension used by a specific importer."
+      responses:
+        200:
+          description: "OK: Successful operation."
+          schema:
+            $ref: "#/definitions/Importer"
+        401:
+          description: "Unauthorized: Missing authorization header."
+        404:
+          description: "Not Found: Importer not found."
+        422:
+          description: "Unprocessable Entity: Invalid or bad parameter provided."
+
+  /importers/{extension}/file:
+    post:
+      tags:
+      - importers
+      summary: "Upload a file to import."
+      operationId: postImportFile
+      security:
+        - Bearer: []
+      parameters:
+      - name: extension
+        in: path
+        required: true
+        type: string
+        description: "The file extension used by a specific importer."
+      responses:
+        201:
+          description: "OK: resource created."
+        401:
+          description: "Unauthorized: Missing authorization header."
+        404:
+          description: "Not Found: Importer not found."
+        422:
+          description: "Unprocessable Entity: Invalid or bad parameter provided."
+
+
+##############################################################################
 # Endpoint - Holidays
 ##############################################################################
 
@@ -8858,6 +8934,28 @@ definitions:
         description: "The module name of the exporter plugin."
         type: string
         example: "exportxml"
+
+
+##############################################################################
+# Model - Importer
+##############################################################################
+
+  Importer:
+    type: object
+    properties:
+      description:
+        description: "A description of the importer."
+        type: string
+        example: "The Gramps XML format is a text version of a Family Tree. It is read-write compatible with the present Gramps database format."
+      extension:
+        description: "The common file extension used for the given export format."
+        type: string
+        example: "gramps"
+      module:
+        description: "The module name of the exporter plugin."
+        type: string
+        example: "importxml"
+
 
 ##############################################################################
 # Model - Report

--- a/gramps_webapi/data/empty_gramps_auth.cfg
+++ b/gramps_webapi/data/empty_gramps_auth.cfg
@@ -1,0 +1,3 @@
+CORS_ORIGINS="*"
+SECRET_KEY="C2eAhXGrXVe-iljXTjnp4paeRT-m68pq"
+USER_DB_URI="sqlite://"

--- a/tests/test_endpoints/test_importers.py
+++ b/tests/test_endpoints/test_importers.py
@@ -1,0 +1,176 @@
+#
+# Gramps Web API - A RESTful API for the Gramps genealogy program
+#
+# Copyright (C) 2020      Christopher Horn
+# Copyright (C) 2022      David M. Straub
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+"""Tests for the /api/importers endpoints."""
+
+import io
+import unittest
+from unittest.mock import patch
+
+from gramps.cli.clidbman import CLIDbManager
+from gramps.gen.dbstate import DbState
+
+from gramps_webapi.app import create_app
+from gramps_webapi.auth.const import ROLE_EDITOR, ROLE_OWNER
+from gramps_webapi.const import ENV_CONFIG_FILE, TEST_EMPTY_GRAMPS_AUTH_CONFIG
+
+from .. import ExampleDbInMemory
+from . import BASE_URL, TEST_USERS, get_test_client
+from .checks import (
+    check_conforms_to_schema,
+    check_invalid_semantics,
+    check_requires_token,
+    check_resource_missing,
+    check_success,
+)
+from .util import fetch_header
+
+TEST_URL = BASE_URL + "/importers/"
+
+
+class TestImporters(unittest.TestCase):
+    """Test cases for the /api/importers endpoint."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Test class setup."""
+        cls.client = get_test_client()
+
+    def test_get_exporters_requires_token(self):
+        """Test authorization required."""
+        check_requires_token(self, TEST_URL)
+
+    def test_get_exporters_conforms_to_schema(self):
+        """Test conformity to schema."""
+        check_conforms_to_schema(self, TEST_URL, "Importer")
+
+    def test_get_exporters_validate_semantics(self):
+        """Test invalid parameters and values."""
+        check_invalid_semantics(self, TEST_URL + "?test=1")
+
+
+class TestExportersExtension(unittest.TestCase):
+    """Test cases for the /api/importers/{extension} endpoint."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Test class setup."""
+        cls.client = get_test_client()
+
+    def test_get_exporters_extension_requires_token(self):
+        """Test authorization required."""
+        check_requires_token(self, TEST_URL + "gramps")
+
+    def test_get_exporters_extension_conforms_to_schema(self):
+        """Test conformity to schema."""
+        check_conforms_to_schema(self, TEST_URL + "gramps", "Importer")
+
+    def test_get_exporters_extension_missing_content(self):
+        """Test response for missing content."""
+        check_resource_missing(self, TEST_URL + "missing")
+
+    def test_get_exporters_extension_validate_semantics(self):
+        """Test invalid parameters and values."""
+        check_invalid_semantics(self, TEST_URL + "gramps?test=1")
+
+
+class TestImportersExtensionFile(unittest.TestCase):
+    """Test cases for the /api/exporters/{extension}/file endpoint."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Test class setup."""
+        dbman = CLIDbManager(DbState())
+        dbman.create_new_db_cli("empty", dbid="sqlite")
+        with patch.dict(
+            "os.environ",
+            {
+                ENV_CONFIG_FILE: TEST_EMPTY_GRAMPS_AUTH_CONFIG,
+                "TREE": "empty",
+            },
+        ):
+            cls.test_app = create_app()
+        cls.test_app.config["TESTING"] = True
+        cls.client = cls.test_app.test_client()
+        sqlauth = cls.test_app.config["AUTH_PROVIDER"]
+        sqlauth.create_table()
+        for role in TEST_USERS:
+            sqlauth.add_user(
+                name=TEST_USERS[role]["name"],
+                password=TEST_USERS[role]["password"],
+                role=role,
+            )
+
+    def test_importers_empty_db(self):
+        """Test that importers are loaded also for a fresh db."""
+        rv = check_success(self, TEST_URL)
+        assert len(rv) > 0
+
+    def test_importers_wrong_role(self):
+        """Test insufficient permissions."""
+        headers = fetch_header(self.client, role=ROLE_EDITOR)
+        rv = self.client.post(
+            f"{TEST_URL}gramps/file",
+            data=None,
+            headers=headers,
+        )
+        assert rv.status_code == 403
+
+    def test_importers_no_data(self):
+        """Test missing file."""
+        headers = fetch_header(self.client, role=ROLE_OWNER)
+        rv = self.client.post(
+            f"{TEST_URL}gramps/file",
+            data=None,
+            headers=headers,
+        )
+        assert rv.status_code == 500
+
+    def test_importers_example_data(self):
+        """Test importing example.gramps."""
+        example_db = ExampleDbInMemory()
+        file_obj = io.BytesIO()
+        with open(example_db.path, "rb") as f:
+            file_obj.write(f.read())
+        file_obj.seek(0)
+        headers = fetch_header(self.client, role=ROLE_OWNER)
+        # database has no people
+        rv = check_success(self, f"{BASE_URL}/people/")
+        assert len(rv) == 0
+        rv = self.client.post(
+            f"{TEST_URL}gramps/file",
+            data=file_obj,
+            headers=headers,
+        )
+        assert rv.status_code == 201
+        # database has plenty of people
+        rv = check_success(self, f"{BASE_URL}/people/")
+        assert len(rv) == 2157
+        # import again
+        file_obj.seek(0)
+        rv = self.client.post(
+            f"{TEST_URL}gramps/file",
+            data=file_obj,
+            headers=headers,
+        )
+        assert rv.status_code == 201
+        # everything doubled
+        rv = check_success(self, f"{BASE_URL}/people/")
+        assert len(rv) == 2 * 2157


### PR DESCRIPTION
This adds 3 new endpoints in perfect anaology (in fact, mostly copying) the exporters:

- `/api/importers` lists import plugins
- `/api/importers/{extension}` lists a specific import plugin
- `/api/importers/{extension}/file` is a PUT endpoint where a file can be uploaded which will be imported to the database

I decided not to restrict this, so it will also work on a non-empty db just as from the CLI.

However, owner permissions are necessary to POST.

Fixes #287.