### PR TITLE
Allow creating admin user if no user exists

### DIFF
--- a/gramps_webapi/api/__init__.py
+++ b/gramps_webapi/api/__init__.py
@@ -62,7 +62,11 @@ from .resources.timeline import (
     TimelineFamiliesResource,
     TimelinePeopleResource,
 )
-from .resources.token import TokenRefreshResource, TokenResource
+from .resources.token import (
+    TokenRefreshResource,
+    TokenResource,
+    TokenCreateOwnerResource,
+)
 from .resources.translations import TranslationResource, TranslationsResource
 from .resources.types import (
     CustomTypeResource,
@@ -75,6 +79,7 @@ from .resources.types import (
 from .resources.user import (
     UserChangePasswordResource,
     UserConfirmEmailResource,
+    UserCreateOwnerResource,
     UserRegisterResource,
     UserResetPasswordResource,
     UserResource,
@@ -101,6 +106,7 @@ register_endpt(TransactionsResource, "/transactions/", "transactions")
 # Token
 register_endpt(TokenResource, "/token/", "token")
 register_endpt(TokenRefreshResource, "/token/refresh/", "token_refresh")
+register_endpt(TokenCreateOwnerResource, "/token/create_owner/", "token_create_owner")
 # People
 register_endpt(
     PersonTimelineResource, "/people/<string:handle>/timeline", "person-timeline"
@@ -220,6 +226,11 @@ register_endpt(
     UserRegisterResource,
     "/users/<string:user_name>/register/",
     "register",
+)
+register_endpt(
+    UserCreateOwnerResource,
+    "/users/<string:user_name>/create_owner/",
+    "user_create_owner",
 )
 register_endpt(
     UserConfirmEmailResource,

--- a/gramps_webapi/api/resources/user.py
+++ b/gramps_webapi/api/resources/user.py
@@ -37,8 +37,10 @@ from ...auth.const import (
     PERM_EDIT_USER_ROLE,
     PERM_VIEW_OTHER_USER,
     ROLE_DISABLED,
+    ROLE_OWNER,
     ROLE_UNCONFIRMED,
     SCOPE_CONF_EMAIL,
+    SCOPE_CREATE_OWNER,
     SCOPE_RESET_PW,
 )
 from ..auth import require_permissions
@@ -209,6 +211,43 @@ class UserRegisterResource(Resource):
         return "", 201
 
 
+class UserCreateOwnerResource(LimitedScopeProtectedResource):
+    """Resource for creating an owner when the user database is empty."""
+
+    @limiter.limit("1/second")
+    @use_args(
+        {
+            "email": fields.Str(required=True),
+            "full_name": fields.Str(required=True),
+            "password": fields.Str(required=True),
+        },
+        location="json",
+    )
+    def post(self, args, user_name: str):
+        """Create a user with owner permissions."""
+        if user_name == "-":
+            # User name - is not allowed
+            abort(404)
+        auth_provider = current_app.config.get("AUTH_PROVIDER")
+        if auth_provider is None:
+            abort(405)
+        if auth_provider.get_number_users() > 0:
+            # there is already a user in the user DB
+            abort(405)
+        claims = get_jwt()
+        if claims[CLAIM_LIMITED_SCOPE] != SCOPE_CREATE_OWNER:
+            # This is a wrong token!
+            abort(403)
+        auth_provider.add_user(
+            name=user_name,
+            password=args["password"],
+            email=args["email"],
+            fullname=args["full_name"],
+            role=ROLE_OWNER,
+        )
+        return "", 201
+
+
 class UserChangePasswordResource(UserChangeBase):
     """Resource for changing a user password."""
 
@@ -269,7 +308,8 @@ class UserResetPasswordResource(LimitedScopeProtectedResource):
     """Resource for resetting a user password."""
 
     @use_args(
-        {"new_password": fields.Str(required=True)}, location="json",
+        {"new_password": fields.Str(required=True)},
+        location="json",
     )
     def post(self, args):
         """Post new password."""

--- a/gramps_webapi/api/resources/user.py
+++ b/gramps_webapi/api/resources/user.py
@@ -188,6 +188,9 @@ class UserRegisterResource(Resource):
         auth_provider = current_app.config.get("AUTH_PROVIDER")
         if auth_provider is None:
             abort(405)
+        # do not allow registration if no admin account exists!
+        if auth_provider.get_number_users(roles=(ROLE_OWNER,)) == 0:
+            abort(405)
         try:
             auth_provider.add_user(
                 name=user_name,

--- a/gramps_webapi/auth/__init__.py
+++ b/gramps_webapi/auth/__init__.py
@@ -22,7 +22,7 @@
 import uuid
 from abc import ABCMeta, abstractmethod
 from contextlib import contextmanager
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Dict, List, Optional, Sequence, Set
 
 import sqlalchemy as sa
 from sqlalchemy.exc import IntegrityError
@@ -179,6 +179,17 @@ class SQLAuth:
         with self.session_scope() as session:
             owners = session.query(User).filter_by(role=ROLE_OWNER).all()
             return [user.email for user in owners if user.email]
+
+    def get_number_users(self, roles: Optional[Sequence[int]] = None) -> int:
+        """Get the number of users in the database.
+
+        Optionally, provide an iterable of numeric roles.
+        """
+        with self.session_scope() as session:
+            query = session.query(User)
+            if roles is not None:
+                query = query.filter(User.role.in_(roles))
+            return query.count()
 
 
 class User(Base):

--- a/gramps_webapi/auth/const.py
+++ b/gramps_webapi/auth/const.py
@@ -61,12 +61,22 @@ PERMISSIONS = {
         PERM_ADD_OBJ,
         PERM_DEL_OBJ,
     },
-    ROLE_CONTRIBUTOR: {PERM_EDIT_OWN_USER, PERM_VIEW_PRIVATE, PERM_ADD_OBJ,},
-    ROLE_MEMBER: {PERM_EDIT_OWN_USER, PERM_VIEW_PRIVATE,},
-    ROLE_GUEST: {PERM_EDIT_OWN_USER,},
+    ROLE_CONTRIBUTOR: {
+        PERM_EDIT_OWN_USER,
+        PERM_VIEW_PRIVATE,
+        PERM_ADD_OBJ,
+    },
+    ROLE_MEMBER: {
+        PERM_EDIT_OWN_USER,
+        PERM_VIEW_PRIVATE,
+    },
+    ROLE_GUEST: {
+        PERM_EDIT_OWN_USER,
+    },
 }
 
 # keys/values for user claims
 CLAIM_LIMITED_SCOPE = "limited_scope"
 SCOPE_RESET_PW = "reset_password"
 SCOPE_CONF_EMAIL = "confirm_email"
+SCOPE_CREATE_OWNER = "create_owner"

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -323,6 +323,8 @@ paths:
           description: "OK: Successful operation."
         401:
           description: "Unauthorized: Missing authorization header."
+        405:
+          description: "Method Not Allowed: authentication disabled or owner account missing."
         409:
           description: "Conflict: user already exists."
         422:

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -144,6 +144,20 @@ paths:
         422:
           description: "Unprocessable Entity: Invalid token."
 
+  /token/create_owner/:
+    get:
+      tags:
+      - authentication
+      summary: "Obtain a JWT access token that allows creating an owner account if no other user exists yet."
+      operationId: getTokenCreateOwner
+      responses:
+        200:
+          description: "OK: Successful operation."
+          schema:
+            $ref: "#/definitions/JWTAccessToken"
+        405:
+          description: "Method Not Allowed: A user already exists or authentication disabled."
+
 
 ##############################################################################
 # Endpoint - Users
@@ -311,6 +325,44 @@ paths:
           description: "Unauthorized: Missing authorization header."
         409:
           description: "Conflict: user already exists."
+        422:
+          description: "Unprocessable Entity: Invalid token."
+
+  /users/{user_name}/create_owner/:
+    post:
+      tags:
+      - users
+      summary: "Create an owner account if no other user exists yet."
+      operationId: createOwner
+      parameters:
+      - name: user_name
+        in: path
+        required: true
+        type: string
+        description: "The user name for the owner account."
+      - name: user_details
+        in: body
+        schema:
+          type: object
+          properties:
+            email:
+              description: "The owner's e-mail address."
+              type: string
+            full_name:
+              description: "The owner's full name."
+              type: string
+            password:
+              description: "The owner's password."
+              type: string
+      responses:
+        201:
+          description: "OK: Successful operation."
+        401:
+          description: "Unauthorized: Missing authorization header."
+        403:
+          description: "Forbidden: wrong token."
+        405:
+          description: "Method Not Allowed: a user already exists or authentication disabled."
         422:
           description: "Unprocessable Entity: Invalid token."
 
@@ -5889,6 +5941,13 @@ definitions:
     properties:
       refresh_token:
         description: Refresh token
+        type: string
+
+  JWTAccessToken:
+    type: object
+    properties:
+      access_token:
+        description: Access token
         type: string
 
 ##############################################################################

--- a/tests/test_sqlauth.py
+++ b/tests/test_sqlauth.py
@@ -98,3 +98,16 @@ class TestSQLAuth(unittest.TestCase):
         self.assertNotIn(PERM_DEL_USER, sqlauth.get_permissions("test_guest"))
         self.assertIn(PERM_EDIT_OWN_USER, sqlauth.get_permissions("test_owner"))
         self.assertIn(PERM_EDIT_OWN_USER, sqlauth.get_permissions("test_guest"))
+
+    def test_count_users(self):
+        sqlauth = SQLAuth("sqlite://", logging=False)
+        sqlauth.create_table()
+        assert sqlauth.get_number_users() == 0
+        sqlauth.add_user("user1", "123", role=1)
+        sqlauth.add_user("user2", "123", role=1)
+        sqlauth.add_user("user3", "123", role=3)
+        sqlauth.add_user("user4", "123", role=4)
+        assert sqlauth.get_number_users() == 4
+        assert sqlauth.get_number_users((1,)) == 2
+        assert sqlauth.get_number_users((2,)) == 0
+        assert sqlauth.get_number_users((1, 3)) == 3


### PR DESCRIPTION
This implements #288 by adding the following endpoints:

- `/api/token/create_admin` allows fetching a special one-time token without supplying any credentials, but only if the user database is empty
- `/api/users/<username>/create_admin` allows creating a new admin (owner) account by using the one-time token.

Fixes #288.

API spec to be updated.