### PR TITLE
Add endpoint for modifying configuration

### DIFF
--- a/gramps_webapi/api/__init__.py
+++ b/gramps_webapi/api/__init__.py
@@ -1,7 +1,7 @@
 #
 # Gramps Web API - A RESTful API for the Gramps genealogy program
 #
-# Copyright (C) 2020      David Straub
+# Copyright (C) 2020-2022      David Straub
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -31,6 +31,7 @@ from .media import MediaHandler
 from .resources.base import Resource
 from .resources.bookmarks import BookmarkResource, BookmarksResource
 from .resources.citations import CitationResource, CitationsResource
+from .resources.config import ConfigResource, ConfigsResource
 from .resources.events import EventResource, EventSpanResource, EventsResource
 from .resources.exporters import (
     ExporterFileResource,
@@ -54,6 +55,7 @@ from .resources.metadata import MetadataResource
 from .resources.name_formats import NameFormatsResource
 from .resources.name_groups import NameGroupsResource
 from .resources.notes import NoteResource, NotesResource
+from .resources.objects import CreateObjectsResource
 from .resources.people import PeopleResource, PersonResource
 from .resources.places import PlaceResource, PlacesResource
 from .resources.relations import RelationResource, RelationsResource
@@ -73,6 +75,8 @@ from .resources.token import (
     TokenResource,
     TokenCreateOwnerResource,
 )
+from .resources.token import TokenRefreshResource, TokenResource
+from .resources.transactions import TransactionsResource
 from .resources.translations import TranslationResource, TranslationsResource
 from .resources.types import (
     CustomTypeResource,
@@ -92,8 +96,6 @@ from .resources.user import (
     UsersResource,
     UserTriggerResetPasswordResource,
 )
-from .resources.objects import CreateObjectsResource
-from .resources.transactions import TransactionsResource
 from .util import make_cache_key_thumbnails, use_args
 
 api_blueprint = Blueprint("api", __name__, url_prefix=API_PREFIX)
@@ -265,6 +267,18 @@ register_endpt(
 )
 # Search
 register_endpt(SearchResource, "/search/", "search")
+
+# Config
+register_endpt(
+    ConfigsResource,
+    "/config/",
+    "configs",
+)
+register_endpt(
+    ConfigResource,
+    "/config/<string:key>/",
+    "config",
+)
 
 # Media files
 register_endpt(

--- a/gramps_webapi/api/resources/config.py
+++ b/gramps_webapi/api/resources/config.py
@@ -1,0 +1,98 @@
+#
+# Gramps Web API - A RESTful API for the Gramps genealogy program
+#
+# Copyright (C) 2022      David Straub
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+"""User administration resources."""
+
+import datetime
+from gettext import gettext as _
+
+from flask import abort, current_app, jsonify, render_template
+from flask_jwt_extended import create_access_token, get_jwt, get_jwt_identity
+from flask_limiter import Limiter
+from flask_limiter.util import get_remote_address
+from webargs import fields
+
+from ...auth.const import PERM_EDIT_SETTINGS, PERM_VIEW_SETTINGS
+from ...const import DB_CONFIG_ALLOWED_KEYS
+from ..auth import require_permissions
+from ..util import use_args
+from . import ProtectedResource, Resource
+
+limiter = Limiter(key_func=get_remote_address)
+
+
+class ConfigsResource(ProtectedResource):
+    """Resource for configuration settings."""
+
+    def get(self):
+        """Get all config settings."""
+        require_permissions([PERM_VIEW_SETTINGS])
+        auth_provider = current_app.config.get("AUTH_PROVIDER")
+        if auth_provider is None:
+            abort(405)
+        return jsonify(auth_provider.config_get_all()), 200
+
+
+class ConfigResource(ProtectedResource):
+    """Resource for a single config setting."""
+
+    def get(self, key: str):
+        """Get a config setting."""
+        require_permissions([PERM_VIEW_SETTINGS])
+        auth_provider = current_app.config.get("AUTH_PROVIDER")
+        if auth_provider is None:
+            abort(405)
+        if key not in DB_CONFIG_ALLOWED_KEYS:
+            abort(404)
+        val = auth_provider.config_get(key)
+        if val is None:
+            abort(404)
+        return jsonify(val), 200
+
+    @use_args(
+        {
+            "value": fields.Str(required=True),
+        },
+        location="json",
+    )
+    def put(self, args, key: str):
+        """Update a config setting."""
+        require_permissions([PERM_EDIT_SETTINGS])
+        auth_provider = current_app.config.get("AUTH_PROVIDER")
+        if auth_provider is None:
+            abort(405)
+        try:
+            auth_provider.config_set(key=key, value=args["value"])
+        except ValueError:
+            abort(404)  # key not allowed
+        return "", 200
+
+    def delete(self, key: str):
+        """Delete a config setting."""
+        require_permissions([PERM_EDIT_SETTINGS])
+        auth_provider = current_app.config.get("AUTH_PROVIDER")
+        if auth_provider is None:
+            abort(405)
+        try:
+            if auth_provider.config_get(key=key) is None:
+                abort(404)
+        except ValueError:
+            abort(404)
+        auth_provider.config_delete(key=key)
+        return "", 200

--- a/gramps_webapi/api/tasks.py
+++ b/gramps_webapi/api/tasks.py
@@ -1,7 +1,7 @@
 #
 # Gramps Web API - A RESTful API for the Gramps genealogy program
 #
-# Copyright (C) 2021      David Straub
+# Copyright (C) 2021-2022      David Straub
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -23,12 +23,12 @@ from gettext import gettext as _
 from flask import abort, current_app
 
 from .emails import email_confirm_email, email_new_user, email_reset_pw
-from .util import send_email
+from .util import get_config, send_email
 
 
 def send_email_reset_password(email: str, token: str):
     """Send an email for password reset."""
-    base_url = current_app.config["BASE_URL"].rstrip("/")
+    base_url = get_config("BASE_URL").rstrip("/")
     body = email_reset_pw(base_url=base_url, token=token)
     subject = _("Reset your Gramps password")
     send_email(subject=subject, body=body, to=[email])
@@ -36,7 +36,7 @@ def send_email_reset_password(email: str, token: str):
 
 def send_email_confirm_email(email: str, token: str):
     """Send an email to confirm an e-mail address."""
-    base_url = current_app.config["BASE_URL"].rstrip("/")
+    base_url = get_config("BASE_URL").rstrip("/")
     body = email_confirm_email(base_url=base_url, token=token)
     subject = _("Confirm your e-mail address")
     send_email(subject=subject, body=body, to=[email])
@@ -44,7 +44,7 @@ def send_email_confirm_email(email: str, token: str):
 
 def send_email_new_user(username: str, fullname: str, email: str):
     """Send an email to owners to notify of a new registered user."""
-    base_url = current_app.config["BASE_URL"].rstrip("/")
+    base_url = get_config("BASE_URL").rstrip("/")
     body = email_new_user(
         base_url=base_url, username=username, fullname=fullname, email=email
     )

--- a/gramps_webapi/auth/const.py
+++ b/gramps_webapi/auth/const.py
@@ -1,7 +1,7 @@
 #
 # Gramps Web API - A RESTful API for the Gramps genealogy program
 #
-# Copyright (C) 2020      David Straub
+# Copyright (C) 2020-2022      David Straub
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -41,6 +41,8 @@ PERM_EDIT_OBJ = "EditObject"
 PERM_ADD_OBJ = "AddObject"
 PERM_DEL_OBJ = "DeleteObject"
 PERM_IMPORT_FILE = "ImportFile"
+PERM_VIEW_SETTINGS = "ViewSettings"
+PERM_EDIT_SETTINGS = "EditSettings"
 
 PERMISSIONS = {
     ROLE_OWNER: {
@@ -55,6 +57,8 @@ PERMISSIONS = {
         PERM_ADD_OBJ,
         PERM_DEL_OBJ,
         PERM_IMPORT_FILE,
+        PERM_VIEW_SETTINGS,
+        PERM_EDIT_SETTINGS,
     },
     ROLE_EDITOR: {
         PERM_EDIT_OWN_USER,

--- a/gramps_webapi/config.py
+++ b/gramps_webapi/config.py
@@ -1,7 +1,7 @@
 #
 # Gramps Web API - A RESTful API for the Gramps genealogy program
 #
-# Copyright (C) 2020      David Straub
+# Copyright (C) 2020-2022      David Straub
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -29,7 +29,7 @@ class DefaultConfig(object):
     PROPAGATE_EXCEPTIONS = True
     SEARCH_INDEX_DIR = os.getenv("SEARCH_INDEX_DIR", "indexdir")
     EMAIL_HOST = os.getenv("EMAIL_HOST", "localhost")
-    EMAIL_PORT = int(os.getenv("EMAIL_PORT", "465"))
+    EMAIL_PORT = os.getenv("EMAIL_PORT", "465")
     EMAIL_HOST_USER = os.getenv("EMAIL_HOST_USER", "")
     EMAIL_HOST_PASSWORD = os.getenv("EMAIL_HOST_PASSWORD", "")
     EMAIL_USE_TLS = True

--- a/gramps_webapi/const.py
+++ b/gramps_webapi/const.py
@@ -1,7 +1,7 @@
 #
 # Gramps Web API - A RESTful API for the Gramps genealogy program
 #
-# Copyright (C) 2020      David Straub
+# Copyright (C) 2020-20202      David Straub
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -39,6 +39,17 @@ TEST_EXAMPLE_GRAMPS_AUTH_CONFIG = resource_filename(
 TEST_EMPTY_GRAMPS_AUTH_CONFIG = resource_filename(
     "gramps_webapi", "data/empty_gramps_auth.cfg"
 )
+
+# allowed db config keys
+DB_CONFIG_ALLOWED_KEYS = [
+    "EMAIL_HOST",
+    "EMAIL_PORT",
+    "EMAIL_HOST_USER",
+    "EMAIL_HOST_PASSWORD",
+    "DEFAULT_FROM_EMAIL",
+    "BASE_URL",
+]
+
 
 # environment variables
 ENV_CONFIG_FILE = "GRAMPS_API_CONFIG"

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -502,6 +502,124 @@ paths:
         405:
           description: "Method Not Allowed: No authorization provider configured."
 
+##############################################################################
+# Endpoint - Config
+##############################################################################
+
+  /config:
+    get:
+      tags:
+      - configuration
+      summary: "List configuration settings."
+      operationId: getConfigs
+      security:
+        - Bearer: []
+      responses:
+        200:
+          description: "OK: Successful operation."
+        401:
+          description: "Unauthorized: Missing authorization header."
+        422:
+          description: "Unprocessable Entity: Invalid token."
+
+  /config/{key}:
+    parameters:
+      - name: key
+        in: path
+        required: true
+        type: string
+        description: "The setting key."
+    get:
+      tags:
+      - configuration
+      summary: "Return the value of a configuration setting."
+      operationId: getConfig
+      security:
+        - Bearer: []
+      responses:
+        200:
+          description: "OK: Successful operation."
+        401:
+          description: "Unauthorized: Missing authorization header."
+        404:
+          description: "Not found: setting does not exist."
+        422:
+          description: "Unprocessable Entity: Invalid token."
+    put:
+      tags:
+      - configuration
+      summary: "Update an existing setting."
+      operationId: updateConfig
+      security:
+        - Bearer: []
+      parameters:
+      - name: config_details
+        in: body
+        schema:
+          type: object
+          properties:
+            value:
+              description: "The value of the setting."
+              type: string
+      responses:
+        200:
+          description: "OK: Successful operation."
+        401:
+          description: "Unauthorized: Missing authorization header."
+        403:
+          description: "Unauthorized: insufficient permissions."
+        404:
+          description: "Not found: setting does not exist."
+        422:
+          description: "Unprocessable Entity: Invalid token."
+    post:
+      tags:
+      - configuration
+      summary: "Add a value to a setting."
+      operationId: setConfig
+      security:
+        - Bearer: []
+      parameters:
+      - name: config_details
+        in: body
+        schema:
+          type: object
+          properties:
+            value:
+              description: "The value of the setting."
+              type: string
+      responses:
+        201:
+          description: "OK: Successful operation."
+        401:
+          description: "Unauthorized: Missing authorization header."
+        403:
+          description: "Unauthorized: insufficient permissions."
+        404:
+          description: "Not found: setting does not exist."
+        422:
+          description: "Unprocessable Entity: Invalid token."
+    delete:
+      tags:
+      - configuration
+      summary: "Delete the setting."
+      operationId: deleteConfig
+      security:
+        - Bearer: []
+      responses:
+        200:
+          description: "OK: Successful operation."
+        400:
+          description: "Bad Request: Malformed request could not be parsed."
+        401:
+          description: "Unauthorized: Missing authorization header."
+        403:
+          description: "Unauthorized: insufficient permissions."
+        404:
+          description: "Not found: setting does not exist."
+        422:
+          description: "Unprocessable Entity: Invalid or bad parameter provided."
+
 
 ##############################################################################
 # Endpoint - People

--- a/tests/test_endpoints/test_config.py
+++ b/tests/test_endpoints/test_config.py
@@ -1,0 +1,157 @@
+#
+# Gramps Web API - A RESTful API for the Gramps genealogy program
+#
+# Copyright (C) 2022      David Straub
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+"""Tests for the `gramps_webapi.api.resources.user` module."""
+
+import re
+import unittest
+from unittest.mock import patch
+
+from gramps.cli.clidbman import CLIDbManager
+from gramps.gen.dbstate import DbState
+
+from gramps_webapi.app import create_app
+from gramps_webapi.auth.const import (
+    ROLE_MEMBER,
+    ROLE_OWNER,
+)
+from gramps_webapi.const import ENV_CONFIG_FILE, TEST_AUTH_CONFIG
+
+from . import BASE_URL
+
+
+class TestConfig(unittest.TestCase):
+    """Test cases for the /api/config/ endpoints."""
+
+    def setUp(self):
+        self.name = "Test Web API"
+        self.dbman = CLIDbManager(DbState())
+        _, _name = self.dbman.create_new_db_cli(self.name, dbid="sqlite")
+        with patch.dict("os.environ", {ENV_CONFIG_FILE: TEST_AUTH_CONFIG}):
+            self.app = create_app()
+        self.app.config["TESTING"] = True
+        self.client = self.app.test_client()
+        sqlauth = self.app.config["AUTH_PROVIDER"]
+        sqlauth.create_table()
+        sqlauth.add_user(
+            name="user", password="123", email="test1@example.com", role=ROLE_MEMBER
+        )
+        sqlauth.add_user(
+            name="admin", password="123", email="test2@example.com", role=ROLE_OWNER
+        )
+        self.ctx = self.app.test_request_context()
+        self.ctx.push()
+        rv = self.client.post(
+            BASE_URL + "/token/", json={"username": "user", "password": "123"}
+        )
+        self.header_member = {"Authorization": f"Bearer {rv.json['access_token']}"}
+        rv = self.client.post(
+            BASE_URL + "/token/", json={"username": "admin", "password": "123"}
+        )
+        self.header_owner = {"Authorization": f"Bearer {rv.json['access_token']}"}
+
+    def tearDown(self):
+        self.ctx.pop()
+        self.dbman.remove_database(self.name)
+
+    def test_get_config(self):
+        rv = self.client.get(
+            f"{BASE_URL}/config/",
+            headers=self.header_member,
+        )
+        assert rv.status_code == 403
+        rv = self.client.get(
+            f"{BASE_URL}/config/",
+            headers=self.header_owner,
+        )
+        assert rv.status_code == 200
+        assert rv.json == {}
+
+    def test_set_config_unauth(self):
+        rv = self.client.put(
+            f"{BASE_URL}/config/EMAIL_HOST/",
+            headers=self.header_member,
+            json={"value": "myhost"},
+        )
+        assert rv.status_code == 403
+
+    def test_set_config_put(self):
+        rv = self.client.put(
+            f"{BASE_URL}/config/EMAIL_HOST/",
+            headers=self.header_owner,
+            json={"value": "host1"},
+        )
+        assert rv.status_code == 200
+        rv = self.client.get(
+            f"{BASE_URL}/config/EMAIL_HOST/", headers=self.header_owner
+        )
+        assert rv.status_code == 200
+        assert rv.json == "host1"
+
+    def test_config_delete(self):
+        rv = self.client.put(
+            f"{BASE_URL}/config/EMAIL_HOST/",
+            headers=self.header_owner,
+            json={"value": "host2"},
+        )
+        rv = self.client.get(
+            f"{BASE_URL}/config/EMAIL_HOST/", headers=self.header_owner
+        )
+        assert rv.status_code == 200
+        assert rv.json == "host2"
+        rv = self.client.delete(
+            f"{BASE_URL}/config/EMAIL_HOST/",
+            headers=self.header_owner,
+        )
+        rv = self.client.get(
+            f"{BASE_URL}/config/EMAIL_HOST/", headers=self.header_owner
+        )
+        assert rv.status_code == 404
+
+    def test_config_reset_password(self):
+        """Check that the config options are picked up in the reset email."""
+
+        def get_from_host():
+            with patch("smtplib.SMTP_SSL") as mock_smtp:
+                self.client.post(f"{BASE_URL}/users/user/password/reset/trigger/")
+                context = mock_smtp.return_value
+                context.send_message.assert_called()
+                name, args, kwargs = context.method_calls.pop(0)
+                msg = args[0]
+                body = msg.get_body().get_payload().replace("=\n", "")
+                matches = re.findall(r".*(https?://[^/]+)/api", body)
+                host = matches[0]
+                return msg["From"], host
+
+        from_email, host = get_from_host()
+        assert from_email == ""
+        assert host == "http://localhost"
+        self.client.put(
+            f"{BASE_URL}/config/BASE_URL/",
+            headers=self.header_owner,
+            json={"value": "https://www.example.com"},
+        )
+        self.client.put(
+            f"{BASE_URL}/config/DEFAULT_FROM_EMAIL/",
+            headers=self.header_owner,
+            json={"value": "from@example.com"},
+        )
+        from_email, host = get_from_host()
+        assert from_email == "from@example.com"
+        assert host == "https://www.example.com"

--- a/tests/test_sqlauth.py
+++ b/tests/test_sqlauth.py
@@ -1,7 +1,7 @@
 #
 # Gramps Web API - A RESTful API for the Gramps genealogy program
 #
-# Copyright (C) 2020      David Straub
+# Copyright (C) 2020-2022      David Straub
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -111,3 +111,27 @@ class TestSQLAuth(unittest.TestCase):
         assert sqlauth.get_number_users((1,)) == 2
         assert sqlauth.get_number_users((2,)) == 0
         assert sqlauth.get_number_users((1, 3)) == 3
+
+
+class TestConfig(unittest.TestCase):
+    def test_add_user(self):
+        sqlauth = SQLAuth("sqlite://", logging=False)
+        sqlauth.create_table()
+        assert sqlauth.config_get_all() == {}
+        assert sqlauth.config_get("nope") is None
+        with self.assertRaises(ValueError):
+            sqlauth.config_set("key1", "value1")
+        sqlauth.config_set("EMAIL_HOST", "value1")
+        assert sqlauth.config_get("EMAIL_HOST") == "value1"
+        sqlauth.config_set("EMAIL_HOST", "value2")
+        assert sqlauth.config_get("EMAIL_HOST") == "value2"
+        sqlauth.config_set("EMAIL_HOST", 1)
+        assert sqlauth.config_get("EMAIL_HOST") == "1"
+        sqlauth.config_set("EMAIL_PORT", 2)
+        assert sqlauth.config_get("EMAIL_PORT") == "2"
+        sqlauth.config_delete("EMAIL_HOST")
+        assert sqlauth.config_get("EMAIL_HOST") is None
+        assert sqlauth.config_get("EMAIL_PORT") == "2"
+        assert sqlauth.config_get("nope") is None
+        sqlauth.config_delete("nope")
+        assert sqlauth.config_get("nope") is None


### PR DESCRIPTION
Closes #294.

This adds the following endpoints:

- `/api/config` - GET: list settings
- `/api/config/{key}` - GET: show setting, PUT/POST: set setting, DELETE: remove setting (fall back to environment or config file if exists)

The following config keys can be set via the API:

```python
DB_CONFIG_ALLOWED_KEYS = [
    "EMAIL_HOST",
    "EMAIL_PORT",
    "EMAIL_HOST_USER",
    "EMAIL_HOST_PASSWORD",
    "DEFAULT_FROM_EMAIL",
    "BASE_URL",
]
```

Those are the ones that should be relevant for onboarding a new instance.