### PR TITLE
Generate flask secret in docker entrypoint

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -14,6 +14,18 @@ then
     export STATIC_PATH="/app/static/grampsjs-${GRAMPSJS_VERSION}"
 fi
 
+# create random flask secret key
+if [ ! -s /app/secret/secret ]
+then
+    mkdir -p /app/secret
+    python3 -c "import secrets;print(secrets.token_urlsafe(32))"  | tr -d "\n" > /app/secret/secret
+fi
+# use the secret key if none is set (will be overridden by config file if present)
+if [ -z "$SECRET_KEY" ]
+then
+    export SECRET_KEY=$(cat /app/secret/secret)
+fi
+
 # Create search index if not exists
 if [ -z "$(ls -A /app/indexdir)" ]
 then


### PR DESCRIPTION
This addition to the entrypoint of the default Docker image does the following:

- Check if the file `/app/secret/secret` exists and is non-empty
- If not, create it by writing a string with 32 random bits to it
- If the environment variable `SECRET_KEY` is not set, set it to the content of the file

Since in `create_app`, we are taking the key from the environment only if it is not present in the config file, this addition does not change anything if `SECRET_KEY` is set in the config file. However, if it is not, it creates a cryptographically safe key so less manual setup is required. To persist this key (otherwise restarting the container would result in all tokens becoming invalid), it is enough to add it to a volume, e.g. by passing `-v secret:/app/secret/secret` when starting the container.

Fixes #296.