### PR TITLE
Create SQLite database if family tree does not exist

### DIFF
--- a/gramps_webapi/app.py
+++ b/gramps_webapi/app.py
@@ -103,6 +103,7 @@ def create_app(db_manager=None):
             name=app.config["TREE"],
             username=app.config["POSTGRES_USER"],
             password=app.config["POSTGRES_PASSWORD"],
+            create_if_missing=True,
         )
     else:
         app.config["DB_MANAGER"] = db_manager

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -19,7 +19,6 @@
 
 """Tests for the `gramps_webapi.dbmanager` module."""
 
-import os
 import unittest
 
 from gramps.cli.clidbman import CLIDbManager
@@ -53,3 +52,18 @@ class TestWebDbManager(unittest.TestCase):
         self.assertFalse(dbmgr.is_locked())
         dbstate.db.close()
         self.assertFalse(dbmgr.is_locked())
+
+
+class TestWebDbManagerCreate(unittest.TestCase):
+    def test_create(self):
+        name = "Test Web Db Manager 2"
+        dbmgr = WebDbManager(name, create_if_missing=True)
+        dbstate = DbState()
+        assert dbmgr.path
+        dbman = CLIDbManager(dbstate)
+        dbman.remove_database(name)
+
+    def test_dont_create(self):
+        name = "Test Web Db Manager 3"
+        with self.assertRaises(ValueError):
+            dbmgr = WebDbManager(name, create_if_missing=False)


### PR DESCRIPTION
To address https://github.com/gramps-project/Gramps.js/issues/81, this PR makes the following change: if `TREE` contains a family tree that does not exist, a new empty SQLite database is created and used. This will simplify deployments of Gramps Web.