### PR TITLE
Allow downloading files as attachment

### DIFF
--- a/gramps_webapi/api/file.py
+++ b/gramps_webapi/api/file.py
@@ -150,7 +150,7 @@ class LocalFileHandler(FileHandler):
                 self.path_rel,
                 mimetype=self.mime,
                 as_attachment=download,
-                attachment_filename=filename,
+                download_name=filename,
             )
         )
         if etag:

--- a/gramps_webapi/api/file.py
+++ b/gramps_webapi/api/file.py
@@ -64,7 +64,7 @@ class FileHandler:
         """Check if the file exists."""
         raise NotImplementedError
 
-    def send_file(self, etag=Optional[str]):
+    def send_file(self, etag=Optional[str], download: bool = False, filename: str = ""):
         """Send media file to client."""
         raise NotImplementedError
 
@@ -140,10 +140,18 @@ class LocalFileHandler(FileHandler):
             stream = BytesIO(f.read())
         return stream
 
-    def send_file(self, etag: Optional[str] = None):
+    def send_file(
+        self, etag: Optional[str] = None, download: bool = False, filename: str = ""
+    ):
         """Send media file to client."""
         res = make_response(
-            send_from_directory(self.base_dir, self.path_rel, mimetype=self.mime)
+            send_from_directory(
+                self.base_dir,
+                self.path_rel,
+                mimetype=self.mime,
+                as_attachment=download,
+                attachment_filename=filename,
+            )
         )
         if etag:
             res.headers["ETag"] = etag


### PR DESCRIPTION
In implementing https://github.com/gramps-project/Gramps.js/issues/96, I realized a change in the backend is needed in order to optionally set the content disposition header of a media file to "attachment" so the file is downloaded with a specifiable file name rather than opening in a new tab (with a useless URL containing the media handle).