### PR TITLE
Allow JWT in query string for reports

### DIFF
--- a/gramps_webapi/api/resources/reports.py
+++ b/gramps_webapi/api/resources/reports.py
@@ -200,6 +200,7 @@ class ReportFileResource(ProtectedResource, GrampsJSONEncoder):
     @use_args(
         {
             "options": fields.Str(validate=validate.Length(min=1)),
+            "jwt": fields.String(required=False),
         },
         location="query",
     )


### PR DESCRIPTION
This allows JWT in query string (rather than request header) for reports, as we already do for exporters. This is needed to ship https://github.com/gramps-project/Gramps.js/issues/42.