### PR TITLE
Allow posting strings to translations endpoint

### DIFF
--- a/gramps_webapi/api/resources/reports.py
+++ b/gramps_webapi/api/resources/reports.py
@@ -200,6 +200,7 @@ class ReportFileResource(ProtectedResource, GrampsJSONEncoder):
     @use_args(
         {
             "options": fields.Str(validate=validate.Length(min=1)),
+            "jwt": fields.String(required=False),
         },
         location="query",
     )

--- a/gramps_webapi/api/resources/translations.py
+++ b/gramps_webapi/api/resources/translations.py
@@ -21,7 +21,7 @@
 """Translate API Resource."""
 
 import json
-from typing import Dict, Union
+from typing import Dict, List, Union
 
 from flask import Response, abort
 from gramps.gen.const import GRAMPS_LOCALE
@@ -72,7 +72,18 @@ class TranslationResource(ProtectedResource, GrampsJSONEncoder):
             strings = json.loads(args["strings"])
         except json.JSONDecodeError:
             abort(400)
+        return self._get_or_post(strings=strings, language=language)
 
+    @use_args(
+        {"strings": fields.List(fields.Str, required=True)},
+        location="json",
+    )
+    def post(self, args: Dict, language: str) -> Response:
+        """Get translation for posted strings."""
+        return self._get_or_post(strings=args["strings"], language=language)
+
+    def _get_or_post(self, strings: List[str], language: str) -> Response:
+        """Get translation."""
         catalog = GRAMPS_LOCALE.get_language_dict()
         for entry in catalog:
             if catalog[entry] == language:

--- a/gramps_webapi/api/util.py
+++ b/gramps_webapi/api/util.py
@@ -28,7 +28,7 @@ from email.message import EmailMessage
 from http import HTTPStatus
 from typing import BinaryIO, Optional, Sequence
 
-from flask import abort, current_app, g, request
+from flask import abort, current_app, g, jsonify, make_response, request
 from gramps.gen.const import GRAMPS_LOCALE
 from gramps.gen.db.base import DbReadBase
 from gramps.gen.errors import HandleError
@@ -47,6 +47,16 @@ from .auth import has_permissions
 class Parser(FlaskParser):
     # raise in case of unknown query arguments
     DEFAULT_UNKNOWN_BY_LOCATION = {"query": RAISE}
+
+    def handle_error(self, error, req, schema, *, error_status_code, error_headers):
+        status_code = error_status_code or self.DEFAULT_VALIDATION_STATUS
+        abort(
+            make_response(jsonify(error.messages), status_code),
+            exc=error,
+            messages=error.messages,
+            schema=schema,
+            headers=error_headers,
+        )
 
 
 parser = Parser()

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -4972,7 +4972,39 @@ paths:
           description: "Not Found: Language code was not found."
         422:
           description: "Unprocessable Entity: Invalid or bad parameter provided."
-
+    post:
+      tags:
+      - translations
+      summary: "Get a translation in a specific language."
+      operationId: getTranslation
+      security:
+        - Bearer: []
+      parameters:
+      - name: language
+        in: path
+        required: true
+        type: string
+        description: "The language code or identifier."
+      - name: strings
+        in: body
+        required: true
+        type: string
+        description: "The list of strings to be translated. These must be provided in JSON format."
+      responses:
+        200:
+          description: "OK: Successful operation."
+          schema:
+            type: array
+            items:
+              $ref: "#/definitions/Translation"
+        400:
+          description: "Bad Request: Malformed request could not be parsed."
+        401:
+          description: "Unauthorized: Missing authorization header."
+        404:
+          description: "Not Found: Language code was not found."
+        422:
+          description: "Unprocessable Entity: Invalid or bad parameter provided."
 
 ##############################################################################
 # Endpoint - Relations


### PR DESCRIPTION
So far, the `/api/translations/<language>` endpoint expected a list of strings as query string. This works, but requires special server settings for maximum request length when querying many strings at once, as Gramps.js does. To avoid issues like that, and after reading [this](https://stackoverflow.com/questions/14202257/design-restful-query-api-with-a-long-list-of-query-parameters), I thought it makes sense to add an alternative method, namely using POST and providing the strings as JSON in the body. This way, we won't have any restrictions on query size. The old GET method is still supported, so it is not a breaking change.