### PR TITLE
Change default locale to en_US

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,10 +15,10 @@ RUN apt-get update && apt-get install -y \
   && rm -rf /var/lib/apt/lists/*
 
 # set locale
-RUN localedef -i en_GB -c -f UTF-8 -A /usr/share/locale/locale.alias en_GB.UTF-8
-ENV LANGUAGE en_GB.utf8
-ENV LANG en_GB.utf8
-ENV LC_ALL en_GB.utf8
+RUN localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+ENV LANGUAGE en_US.utf8
+ENV LANG en_US.utf8
+ENV LC_ALL en_US.utf8
 
 ENV GRAMPS_API_CONFIG=/app/config/config.cfg
 

--- a/gramps_webapi/const.py
+++ b/gramps_webapi/const.py
@@ -144,7 +144,7 @@ LOCALE_MAP = {
     "da": "da_DK",
     "de": "de_DE",
     "el": "el_GR",
-    "en": "en_GB",
+    "en": "en_US",
     "es": "es_ES",
     "fi": "fi_FI",
     "fr": "fr_FR",


### PR DESCRIPTION
The default locale of the Docker image is currently en_GB, but I realized this was a suboptimal choice as the "untranslated" strings in Gramps all correspond to en_US. So in cases where strings are translated at import time (e.g. reports or exporter descriptions), using en_GB will make it impossible to translate (e.g. in cases the word "centre" is involved...).