### PR TITLE
Silence various deprecation warnings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ RUN apt-get update && apt-get install -y \
   poppler-utils ffmpeg libavcodec-extra \
   unzip \
   libpq-dev postgresql-client postgresql-client-common python3-psycopg2 \
-  python3-opencv \
   && rm -rf /var/lib/apt/lists/*
 
 # set locale
@@ -38,6 +37,10 @@ ENV STATIC_PATH=/app/static
 RUN wget https://github.com/gramps-project/addons/archive/refs/heads/master.zip \
     && unzip -p master.zip addons-master/gramps$GRAMPS_VERSION/download/PostgreSQL.addon.tgz | \
     tar -xvz -C /root/.gramps/gramps$GRAMPS_VERSION/plugins && rm master.zip
+
+# install OpenCV
+RUN python3 -m pip install --no-cache-dir --extra-index-url https://www.piwheels.org/simple \
+    opencv-python
 
 # install gunicorn
 RUN python3 -m pip install --no-cache-dir --extra-index-url https://www.piwheels.org/simple \

--- a/gramps_webapi/api/__init__.py
+++ b/gramps_webapi/api/__init__.py
@@ -299,7 +299,10 @@ register_endpt(
 @api_blueprint.route("/media/<string:handle>/thumbnail/<int:size>")
 @jwt_required_ifauth
 @use_args(
-    {"square": fields.Boolean(missing=False), "jwt": fields.String(required=False)},
+    {
+        "square": fields.Boolean(load_default=False),
+        "jwt": fields.String(required=False),
+    },
     location="query",
 )
 @thumbnail_cache.cached(make_cache_key=make_cache_key_thumbnails)
@@ -315,7 +318,10 @@ def get_thumbnail(args, handle, size):
 )
 @jwt_required_ifauth
 @use_args(
-    {"square": fields.Boolean(missing=False), "jwt": fields.String(required=False)},
+    {
+        "square": fields.Boolean(load_default=False),
+        "jwt": fields.String(required=False),
+    },
     location="query",
 )
 @thumbnail_cache.cached(make_cache_key=make_cache_key_thumbnails)
@@ -331,7 +337,10 @@ def get_cropped(args, handle: str, x1: int, y1: int, x2: int, y2: int):
 )
 @jwt_required_ifauth
 @use_args(
-    {"square": fields.Boolean(missing=False), "jwt": fields.String(required=False)},
+    {
+        "square": fields.Boolean(load_default=False),
+        "jwt": fields.String(required=False),
+    },
     location="query",
 )
 @thumbnail_cache.cached(make_cache_key=make_cache_key_thumbnails)

--- a/gramps_webapi/api/resources/base.py
+++ b/gramps_webapi/api/resources/base.py
@@ -162,7 +162,7 @@ class GrampsObjectResource(GrampsObjectResourceHelper, Resource):
 
     @use_args(
         {
-            "backlinks": fields.Boolean(missing=False),
+            "backlinks": fields.Boolean(load_default=False),
             "extend": fields.DelimitedList(
                 fields.Str(validate=validate.Length(min=1)),
                 validate=validate.ContainsOnly(
@@ -192,7 +192,9 @@ class GrampsObjectResource(GrampsObjectResourceHelper, Resource):
             ),
             "format_options": fields.Str(validate=validate.Length(min=1)),
             "keys": fields.DelimitedList(fields.Str(validate=validate.Length(min=1))),
-            "locale": fields.Str(missing=None, validate=validate.Length(min=1, max=5)),
+            "locale": fields.Str(
+                load_default=None, validate=validate.Length(min=1, max=5)
+            ),
             "profile": fields.DelimitedList(
                 fields.Str(validate=validate.Length(min=1)),
                 validate=validate.ContainsOnly(
@@ -211,8 +213,8 @@ class GrampsObjectResource(GrampsObjectResourceHelper, Resource):
             "skipkeys": fields.DelimitedList(
                 fields.Str(validate=validate.Length(min=1))
             ),
-            "soundex": fields.Boolean(missing=False),
-            "strip": fields.Boolean(missing=False),
+            "soundex": fields.Boolean(load_default=False),
+            "strip": fields.Boolean(load_default=False),
         },
         location="query",
     )
@@ -284,9 +286,9 @@ class GrampsObjectsResource(GrampsObjectResourceHelper, Resource):
 
     @use_args(
         {
-            "backlinks": fields.Boolean(missing=False),
+            "backlinks": fields.Boolean(load_default=False),
             "dates": fields.Str(
-                missing=None,
+                load_default=None,
                 validate=validate.Regexp(
                     r"^([0-9]+|\*)/([1-9]|1[0-2]|\*)/([1-9]|1[0-9]|2[0-9]|3[0-1]|\*)$|"
                     r"^-[0-9]+/([1-9]|1[0-2])/([1-9]|1[0-9]|2[0-9]|3[0-1])$|"
@@ -326,9 +328,11 @@ class GrampsObjectsResource(GrampsObjectResourceHelper, Resource):
             "format_options": fields.Str(validate=validate.Length(min=1)),
             "gramps_id": fields.Str(validate=validate.Length(min=1)),
             "keys": fields.DelimitedList(fields.Str(validate=validate.Length(min=1))),
-            "locale": fields.Str(missing=None, validate=validate.Length(min=1, max=5)),
-            "page": fields.Integer(missing=0, validate=validate.Range(min=1)),
-            "pagesize": fields.Integer(missing=20, validate=validate.Range(min=1)),
+            "locale": fields.Str(
+                load_default=None, validate=validate.Length(min=1, max=5)
+            ),
+            "page": fields.Integer(load_default=0, validate=validate.Range(min=1)),
+            "pagesize": fields.Integer(load_default=20, validate=validate.Range(min=1)),
             "profile": fields.DelimitedList(
                 fields.Str(validate=validate.Length(min=1)),
                 validate=validate.ContainsOnly(
@@ -349,9 +353,9 @@ class GrampsObjectsResource(GrampsObjectResourceHelper, Resource):
                 fields.Str(validate=validate.Length(min=1))
             ),
             "sort": fields.DelimitedList(fields.Str(validate=validate.Length(min=1))),
-            "soundex": fields.Boolean(missing=False),
-            "strip": fields.Boolean(missing=False),
-            "filemissing": fields.Boolean(missing=False),
+            "soundex": fields.Boolean(load_default=False),
+            "strip": fields.Boolean(load_default=False),
+            "filemissing": fields.Boolean(load_default=False),
         },
         location="query",
     )

--- a/gramps_webapi/api/resources/events.py
+++ b/gramps_webapi/api/resources/events.py
@@ -87,10 +87,12 @@ class EventSpanResource(ProtectedResource, GrampsJSONEncoder):
 
     @use_args(
         {
-            "as_age": fields.Boolean(missing=True),
-            "locale": fields.Str(missing=None, validate=validate.Length(min=1, max=5)),
+            "as_age": fields.Boolean(load_default=True),
+            "locale": fields.Str(
+                load_default=None, validate=validate.Length(min=1, max=5)
+            ),
             "precision": fields.Integer(
-                missing=2, validate=validate.Range(min=1, max=3)
+                load_default=2, validate=validate.Range(min=1, max=3)
             ),
         },
         location="query",

--- a/gramps_webapi/api/resources/exporters.py
+++ b/gramps_webapi/api/resources/exporters.py
@@ -183,19 +183,19 @@ class ExporterFileResource(ProtectedResource, GrampsJSONEncoder):
 
     @use_args(
         {
-            "compress": fields.Boolean(missing=True),
-            "current_year": fields.Integer(missing=None),
-            "event": fields.Str(missing=None),
-            "gramps_id": fields.Str(missing=None),
-            "handle": fields.Str(missing=None),
-            "include_children": fields.Boolean(missing=True),
-            "include_individuals": fields.Boolean(missing=True),
-            "include_marriages": fields.Boolean(missing=True),
-            "include_media": fields.Boolean(missing=True),
-            "include_places": fields.Boolean(missing=True),
-            "include_witnesses": fields.Boolean(missing=True),
+            "compress": fields.Boolean(load_default=True),
+            "current_year": fields.Integer(load_default=None),
+            "event": fields.Str(load_default=None),
+            "gramps_id": fields.Str(load_default=None),
+            "handle": fields.Str(load_default=None),
+            "include_children": fields.Boolean(load_default=True),
+            "include_individuals": fields.Boolean(load_default=True),
+            "include_marriages": fields.Boolean(load_default=True),
+            "include_media": fields.Boolean(load_default=True),
+            "include_places": fields.Boolean(load_default=True),
+            "include_witnesses": fields.Boolean(load_default=True),
             "living": fields.Str(
-                missing="IncludeAll",
+                load_default="IncludeAll",
                 validate=validate.OneOf(
                     [
                         "IncludeAll",
@@ -206,16 +206,16 @@ class ExporterFileResource(ProtectedResource, GrampsJSONEncoder):
                     ]
                 ),
             ),
-            "locale": fields.Str(missing=None),
-            "note": fields.Str(missing=None),
-            "person": fields.Str(missing=None),
-            "private": fields.Boolean(missing=False),
-            "reference": fields.Boolean(missing=False),
+            "locale": fields.Str(load_default=None),
+            "note": fields.Str(load_default=None),
+            "person": fields.Str(load_default=None),
+            "private": fields.Boolean(load_default=False),
+            "reference": fields.Boolean(load_default=False),
             "sequence": fields.Str(
-                missing="privacy,living,person,event,note,reference"
+                load_default="privacy,living,person,event,note,reference"
             ),
-            "translate_headers": fields.Boolean(missing=True),
-            "years_after_death": fields.Integer(missing=0),
+            "translate_headers": fields.Boolean(load_default=True),
+            "years_after_death": fields.Integer(load_default=0),
             "jwt": fields.String(required=False),
         },
         location="query",

--- a/gramps_webapi/api/resources/facts.py
+++ b/gramps_webapi/api/resources/facts.py
@@ -97,10 +97,10 @@ class FactsResource(ProtectedResource, GrampsJSONEncoder):
 
     @use_args(
         {
-            "gramps_id": fields.Str(missing=None, validate=validate.Length(min=1)),
-            "handle": fields.Str(missing=None, validate=validate.Length(min=1)),
+            "gramps_id": fields.Str(load_default=None, validate=validate.Length(min=1)),
+            "handle": fields.Str(load_default=None, validate=validate.Length(min=1)),
             "living": fields.Str(
-                missing="IncludeAll",
+                load_default="IncludeAll",
                 validate=validate.OneOf(
                     [
                         "IncludeAll",
@@ -111,10 +111,12 @@ class FactsResource(ProtectedResource, GrampsJSONEncoder):
                     ]
                 ),
             ),
-            "locale": fields.Str(missing=None, validate=validate.Length(min=2, max=5)),
-            "person": fields.Str(missing=None, validate=validate.Length(min=1)),
-            "private": fields.Boolean(missing=False),
-            "rank": fields.Integer(missing=1, validate=validate.Range(min=1)),
+            "locale": fields.Str(
+                load_default=None, validate=validate.Length(min=2, max=5)
+            ),
+            "person": fields.Str(load_default=None, validate=validate.Length(min=1)),
+            "private": fields.Boolean(load_default=False),
+            "rank": fields.Integer(load_default=1, validate=validate.Range(min=1)),
         },
         location="query",
     )

--- a/gramps_webapi/api/resources/file.py
+++ b/gramps_webapi/api/resources/file.py
@@ -45,7 +45,7 @@ class MediaFileResource(ProtectedResource):
 
     @use_args(
         {
-            "download": fields.Boolean(missing=False),
+            "download": fields.Boolean(load_default=False),
             "jwt": fields.String(required=False),
         },
         location="query",
@@ -67,7 +67,7 @@ class MediaFileResource(ProtectedResource):
 
     @use_args(
         {
-            "uploadmissing": fields.Boolean(missing=False),
+            "uploadmissing": fields.Boolean(load_default=False),
         },
         location="query",
     )

--- a/gramps_webapi/api/resources/filters.py
+++ b/gramps_webapi/api/resources/filters.py
@@ -161,7 +161,7 @@ class RuleSchema(Schema):
 
     name = fields.Str(required=True, validate=validate.Length(min=1))
     values = fields.List(fields.Raw, required=False)
-    regex = fields.Boolean(required=False, missing=False)
+    regex = fields.Boolean(required=False, load_default=False)
 
 
 class FilterSchema(Schema):
@@ -169,10 +169,10 @@ class FilterSchema(Schema):
 
     function = fields.Str(
         required=False,
-        missing="and",
+        load_default="and",
         validate=validate.OneOf(["and", "or", "xor", "one"]),
     )
-    invert = fields.Boolean(required=False, missing=False)
+    invert = fields.Boolean(required=False, load_default=False)
     rules = fields.List(
         fields.Nested(RuleSchema), required=True, validate=validate.Length(min=1)
     )
@@ -192,7 +192,8 @@ class FiltersResources(ProtectedResource, GrampsJSONEncoder):
     """Filters resources."""
 
     @use_args(
-        {}, location="query",
+        {},
+        location="query",
     )
     def get(self, args: Dict[str, str]) -> Response:
         """Get available custom filters and rules."""
@@ -286,7 +287,10 @@ class FilterResource(ProtectedResource, GrampsJSONEncoder):
         return self.response(200, filter_list[0])
 
     @use_args(
-        {"force": fields.Str(validate=validate.Length(equal=0)),}, location="query",
+        {
+            "force": fields.Str(validate=validate.Length(equal=0)),
+        },
+        location="query",
     )
     def delete(self, args: Dict, namespace: str, name: str) -> Response:
         """Delete a custom filter."""

--- a/gramps_webapi/api/resources/living.py
+++ b/gramps_webapi/api/resources/living.py
@@ -38,13 +38,13 @@ class LivingResource(ProtectedResource, GrampsJSONEncoder):
     @use_args(
         {
             "average_generation_gap": fields.Integer(
-                missing=None, validate=validate.Range(min=1)
+                load_default=None, validate=validate.Range(min=1)
             ),
             "max_age_probably_alive": fields.Integer(
-                missing=None, validate=validate.Range(min=1)
+                load_default=None, validate=validate.Range(min=1)
             ),
             "max_sibling_age_difference": fields.Integer(
-                missing=None, validate=validate.Range(min=1)
+                load_default=None, validate=validate.Range(min=1)
             ),
         },
         location="query",
@@ -72,14 +72,16 @@ class LivingDatesResource(ProtectedResource, GrampsJSONEncoder):
     @use_args(
         {
             "average_generation_gap": fields.Integer(
-                missing=None, validate=validate.Range(min=1)
+                load_default=None, validate=validate.Range(min=1)
             ),
-            "locale": fields.Str(missing=None, validate=validate.Length(min=1, max=5)),
+            "locale": fields.Str(
+                load_default=None, validate=validate.Length(min=1, max=5)
+            ),
             "max_age_probably_alive": fields.Integer(
-                missing=None, validate=validate.Range(min=1)
+                load_default=None, validate=validate.Range(min=1)
             ),
             "max_sibling_age_difference": fields.Integer(
-                missing=None, validate=validate.Range(min=1)
+                load_default=None, validate=validate.Range(min=1)
             ),
         },
         location="query",

--- a/gramps_webapi/api/resources/relations.py
+++ b/gramps_webapi/api/resources/relations.py
@@ -38,8 +38,10 @@ class RelationResource(ProtectedResource, GrampsJSONEncoder):
 
     @use_args(
         {
-            "depth": fields.Integer(missing=15, validate=validate.Range(min=2)),
-            "locale": fields.Str(missing=None, validate=validate.Length(min=1, max=5)),
+            "depth": fields.Integer(load_default=15, validate=validate.Range(min=2)),
+            "locale": fields.Str(
+                load_default=None, validate=validate.Length(min=1, max=5)
+            ),
         },
         location="query",
     )
@@ -76,8 +78,10 @@ class RelationsResource(ProtectedResource, GrampsJSONEncoder):
 
     @use_args(
         {
-            "depth": fields.Integer(missing=15, validate=validate.Range(min=2)),
-            "locale": fields.Str(missing=None, validate=validate.Length(min=1, max=5)),
+            "depth": fields.Integer(load_default=15, validate=validate.Range(min=2)),
+            "locale": fields.Str(
+                load_default=None, validate=validate.Length(min=1, max=5)
+            ),
         },
         location="query",
     )

--- a/gramps_webapi/api/resources/search.py
+++ b/gramps_webapi/api/resources/search.py
@@ -87,10 +87,12 @@ class SearchResource(GrampsJSONEncoder, ProtectedResource):
 
     @use_args(
         {
-            "locale": fields.Str(missing=None, validate=validate.Length(min=1, max=5)),
+            "locale": fields.Str(
+                load_default=None, validate=validate.Length(min=1, max=5)
+            ),
             "query": fields.Str(required=True, validate=validate.Length(min=1)),
-            "page": fields.Int(missing=1, validate=validate.Range(min=1)),
-            "pagesize": fields.Int(missing=20, validate=validate.Range(min=1)),
+            "page": fields.Int(load_default=1, validate=validate.Range(min=1)),
+            "pagesize": fields.Int(load_default=20, validate=validate.Range(min=1)),
             "sort": fields.DelimitedList(fields.Str(validate=validate.Length(min=1))),
             "profile": fields.DelimitedList(
                 fields.Str(validate=validate.Length(min=1)),
@@ -98,7 +100,7 @@ class SearchResource(GrampsJSONEncoder, ProtectedResource):
                     choices=["all", "self", "families", "events", "age", "span"]
                 ),
             ),
-            "strip": fields.Boolean(missing=False),
+            "strip": fields.Boolean(load_default=False),
         },
         location="query",
     )

--- a/gramps_webapi/api/resources/timeline.py
+++ b/gramps_webapi/api/resources/timeline.py
@@ -511,10 +511,10 @@ class PersonTimelineResource(ProtectedResource, GrampsJSONEncoder):
     @use_args(
         {
             "ancestors": fields.Integer(
-                missing=1, validate=validate.Range(min=1, max=5)
+                load_default=1, validate=validate.Range(min=1, max=5)
             ),
             "dates": fields.Str(
-                missing=None,
+                load_default=None,
                 validate=validate.Regexp(
                     r"^-[0-9]+/([1-9]|1[0-2])/([1-9]|1[0-9]|2[0-9]|3[0-1])$|"
                     r"^[0-9]+/([1-9]|1[0-2])/([1-9]|1[0-9]|2[0-9]|3[0-1])-$|"
@@ -522,26 +522,26 @@ class PersonTimelineResource(ProtectedResource, GrampsJSONEncoder):
                     r"[0-9]+/([1-9]|1[0-2])/([1-9]|1[0-9]|2[0-9]|3[0-1])$"
                 ),
             ),
-            "discard_empty": fields.Boolean(missing=True),
+            "discard_empty": fields.Boolean(load_default=True),
             "event_classes": fields.DelimitedList(
                 fields.Str(validate=validate.Length(min=1)),
                 validate=validate.ContainsOnly(choices=EVENT_CATEGORIES),
             ),
             "events": fields.DelimitedList(fields.Str(validate=validate.Length(min=1))),
-            "first": fields.Boolean(missing=True),
+            "first": fields.Boolean(load_default=True),
             "keys": fields.DelimitedList(fields.Str(validate=validate.Length(min=1))),
-            "last": fields.Boolean(missing=True),
-            "locale": fields.Str(missing=None),
+            "last": fields.Boolean(load_default=True),
+            "locale": fields.Str(load_default=None),
             "offspring": fields.Integer(
-                missing=1, validate=validate.Range(min=1, max=5)
+                load_default=1, validate=validate.Range(min=1, max=5)
             ),
-            "omit_anchor": fields.Boolean(missing=True),
-            "page": fields.Integer(missing=0, validate=validate.Range(min=1)),
-            "pagesize": fields.Integer(missing=20, validate=validate.Range(min=1)),
+            "omit_anchor": fields.Boolean(load_default=True),
+            "page": fields.Integer(load_default=0, validate=validate.Range(min=1)),
+            "pagesize": fields.Integer(load_default=20, validate=validate.Range(min=1)),
             "precision": fields.Integer(
-                missing=1, validate=validate.Range(min=1, max=3)
+                load_default=1, validate=validate.Range(min=1, max=3)
             ),
-            "ratings": fields.Boolean(missing=False),
+            "ratings": fields.Boolean(load_default=False),
             "relative_event_classes": fields.DelimitedList(
                 fields.Str(validate=validate.Length(min=1)),
                 validate=validate.ContainsOnly(choices=EVENT_CATEGORIES),
@@ -556,7 +556,7 @@ class PersonTimelineResource(ProtectedResource, GrampsJSONEncoder):
             "skipkeys": fields.DelimitedList(
                 fields.Str(validate=validate.Length(min=1))
             ),
-            "strip": fields.Boolean(missing=False),
+            "strip": fields.Boolean(load_default=False),
         },
         location="query",
     )
@@ -608,7 +608,7 @@ class FamilyTimelineResource(ProtectedResource, GrampsJSONEncoder):
     @use_args(
         {
             "dates": fields.Str(
-                missing=None,
+                load_default=None,
                 validate=validate.Regexp(
                     r"^-[0-9]+/([1-9]|1[0-2])/([1-9]|1[0-9]|2[0-9]|3[0-1])$|"
                     r"^[0-9]+/([1-9]|1[0-2])/([1-9]|1[0-9]|2[0-9]|3[0-1])-$|"
@@ -616,21 +616,21 @@ class FamilyTimelineResource(ProtectedResource, GrampsJSONEncoder):
                     r"[0-9]+/([1-9]|1[0-2])/([1-9]|1[0-9]|2[0-9]|3[0-1])$"
                 ),
             ),
-            "discard_empty": fields.Boolean(missing=True),
+            "discard_empty": fields.Boolean(load_default=True),
             "event_classes": fields.DelimitedList(
                 fields.Str(validate=validate.Length(min=1)),
                 validate=validate.ContainsOnly(choices=EVENT_CATEGORIES),
             ),
             "events": fields.DelimitedList(fields.Str(validate=validate.Length(min=1))),
             "keys": fields.DelimitedList(fields.Str(validate=validate.Length(min=1))),
-            "locale": fields.Str(missing=None),
-            "page": fields.Integer(missing=0, validate=validate.Range(min=1)),
-            "pagesize": fields.Integer(missing=20, validate=validate.Range(min=1)),
-            "ratings": fields.Boolean(missing=False),
+            "locale": fields.Str(load_default=None),
+            "page": fields.Integer(load_default=0, validate=validate.Range(min=1)),
+            "pagesize": fields.Integer(load_default=20, validate=validate.Range(min=1)),
+            "ratings": fields.Boolean(load_default=False),
             "skipkeys": fields.DelimitedList(
                 fields.Str(validate=validate.Length(min=1))
             ),
-            "strip": fields.Boolean(missing=False),
+            "strip": fields.Boolean(load_default=False),
         },
         location="query",
     )
@@ -664,7 +664,7 @@ class TimelinePeopleResource(ProtectedResource, GrampsJSONEncoder):
         {
             "anchor": fields.Str(validate=validate.Length(min=1)),
             "dates": fields.Str(
-                missing=None,
+                load_default=None,
                 validate=validate.Regexp(
                     r"^-[0-9]+/([1-9]|1[0-2])/([1-9]|1[0-9]|2[0-9]|3[0-1])$|"
                     r"^[0-9]+/([1-9]|1[0-2])/([1-9]|1[0-9]|2[0-9]|3[0-1])-$|"
@@ -672,32 +672,34 @@ class TimelinePeopleResource(ProtectedResource, GrampsJSONEncoder):
                     r"[0-9]+/([1-9]|1[0-2])/([1-9]|1[0-9]|2[0-9]|3[0-1])$"
                 ),
             ),
-            "discard_empty": fields.Boolean(missing=True),
+            "discard_empty": fields.Boolean(load_default=True),
             "event_classes": fields.DelimitedList(
                 fields.Str(validate=validate.Length(min=1)),
                 validate=validate.ContainsOnly(choices=EVENT_CATEGORIES),
             ),
             "events": fields.DelimitedList(fields.Str(validate=validate.Length(min=1))),
             "filter": fields.Str(validate=validate.Length(min=1)),
-            "first": fields.Boolean(missing=True),
+            "first": fields.Boolean(load_default=True),
             "handles": fields.DelimitedList(
                 fields.Str(validate=validate.Length(min=1))
             ),
             "keys": fields.DelimitedList(fields.Str(validate=validate.Length(min=1))),
-            "last": fields.Boolean(missing=True),
-            "locale": fields.Str(missing=None, validate=validate.Length(min=1, max=5)),
-            "omit_anchor": fields.Boolean(missing=True),
-            "page": fields.Integer(missing=0, validate=validate.Range(min=1)),
-            "pagesize": fields.Integer(missing=20, validate=validate.Range(min=1)),
-            "precision": fields.Integer(
-                missing=1, validate=validate.Range(min=1, max=3)
+            "last": fields.Boolean(load_default=True),
+            "locale": fields.Str(
+                load_default=None, validate=validate.Length(min=1, max=5)
             ),
-            "ratings": fields.Boolean(missing=False),
+            "omit_anchor": fields.Boolean(load_default=True),
+            "page": fields.Integer(load_default=0, validate=validate.Range(min=1)),
+            "pagesize": fields.Integer(load_default=20, validate=validate.Range(min=1)),
+            "precision": fields.Integer(
+                load_default=1, validate=validate.Range(min=1, max=3)
+            ),
+            "ratings": fields.Boolean(load_default=False),
             "rules": fields.Str(validate=validate.Length(min=1)),
             "skipkeys": fields.DelimitedList(
                 fields.Str(validate=validate.Length(min=1))
             ),
-            "strip": fields.Boolean(missing=False),
+            "strip": fields.Boolean(load_default=False),
         },
         location="query",
     )
@@ -751,7 +753,7 @@ class TimelineFamiliesResource(ProtectedResource, GrampsJSONEncoder):
     @use_args(
         {
             "dates": fields.Str(
-                missing=None,
+                load_default=None,
                 validate=validate.Regexp(
                     r"^-[0-9]+/([1-9]|1[0-2])/([1-9]|1[0-9]|2[0-9]|3[0-1])$|"
                     r"^[0-9]+/([1-9]|1[0-2])/([1-9]|1[0-9]|2[0-9]|3[0-1])-$|"
@@ -759,7 +761,7 @@ class TimelineFamiliesResource(ProtectedResource, GrampsJSONEncoder):
                     r"[0-9]+/([1-9]|1[0-2])/([1-9]|1[0-9]|2[0-9]|3[0-1])$"
                 ),
             ),
-            "discard_empty": fields.Boolean(missing=True),
+            "discard_empty": fields.Boolean(load_default=True),
             "event_classes": fields.DelimitedList(
                 fields.Str(validate=validate.Length(min=1)),
                 validate=validate.ContainsOnly(choices=EVENT_CATEGORIES),
@@ -770,15 +772,17 @@ class TimelineFamiliesResource(ProtectedResource, GrampsJSONEncoder):
             "handles": fields.DelimitedList(
                 fields.Str(validate=validate.Length(min=1))
             ),
-            "locale": fields.Str(missing=None, validate=validate.Length(min=1, max=5)),
-            "page": fields.Integer(missing=0, validate=validate.Range(min=1)),
-            "pagesize": fields.Integer(missing=20, validate=validate.Range(min=1)),
-            "ratings": fields.Boolean(missing=False),
+            "locale": fields.Str(
+                load_default=None, validate=validate.Length(min=1, max=5)
+            ),
+            "page": fields.Integer(load_default=0, validate=validate.Range(min=1)),
+            "pagesize": fields.Integer(load_default=20, validate=validate.Range(min=1)),
+            "ratings": fields.Boolean(load_default=False),
             "rules": fields.Str(validate=validate.Length(min=1)),
             "skipkeys": fields.DelimitedList(
                 fields.Str(validate=validate.Length(min=1))
             ),
-            "strip": fields.Boolean(missing=False),
+            "strip": fields.Boolean(load_default=False),
         },
         location="query",
     )

--- a/gramps_webapi/api/resources/translations.py
+++ b/gramps_webapi/api/resources/translations.py
@@ -95,7 +95,9 @@ class TranslationsResource(ProtectedResource, GrampsJSONEncoder):
 
     @use_args(
         {
-            "locale": fields.Str(missing=None, validate=validate.Length(min=1, max=5)),
+            "locale": fields.Str(
+                load_default=None, validate=validate.Length(min=1, max=5)
+            ),
             "sort": fields.DelimitedList(fields.Str(validate=validate.Length(min=1))),
         },
         location="query",

--- a/gramps_webapi/api/resources/types.py
+++ b/gramps_webapi/api/resources/types.py
@@ -162,7 +162,7 @@ class DefaultTypesResource(ProtectedResource, GrampsJSONEncoder):
 
     @use_args(
         {
-            "locale": fields.Boolean(missing=False),
+            "locale": fields.Boolean(load_default=False),
         },
         location="query",
     )
@@ -179,7 +179,7 @@ class DefaultTypeResource(ProtectedResource, GrampsJSONEncoder):
 
     @use_args(
         {
-            "locale": fields.Boolean(missing=False),
+            "locale": fields.Boolean(load_default=False),
         },
         location="query",
     )
@@ -245,7 +245,7 @@ class TypesResource(ProtectedResource, GrampsJSONEncoder):
 
     @use_args(
         {
-            "locale": fields.Boolean(missing=False),
+            "locale": fields.Boolean(load_default=False),
         },
         location="query",
     )

--- a/gramps_webapi/auth/sql_guid.py
+++ b/gramps_webapi/auth/sql_guid.py
@@ -36,6 +36,7 @@ class GUID(TypeDecorator):
     """
 
     impl = CHAR
+    cache_ok = True
 
     def load_dialect_impl(self, dialect):
         if dialect.name == "postgresql":

--- a/gramps_webapi/config.py
+++ b/gramps_webapi/config.py
@@ -38,7 +38,7 @@ class DefaultConfig(object):
     CORS_EXPOSE_HEADERS = ["X-Total-Count"]
     STATIC_PATH = os.getenv("STATIC_PATH", "static")
     THUMBNAIL_CACHE_CONFIG = {
-        "CACHE_TYPE": "filesystem",
+        "CACHE_TYPE": "FileSystemCache",
         "CACHE_DIR": "thumbnail_cache",
         "CACHE_THRESHOLD": 1000,
     }

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ with open("gramps_webapi/_version.py") as version_file:
 REQUIREMENTS = [
     "Click>=7.0",
     "Flask>=2.0.0",
-    "Flask-Caching",
+    "Flask-Caching>=2.0.0",
     "Flask-Compress",
     "Flask-Cors",
     "Flask-JWT-Extended>=4.2.1, !=4.4.0, !=4.4.1",

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ REQUIREMENTS = [
     "Flask-Cors",
     "Flask-JWT-Extended>=4.2.1, !=4.4.0, !=4.4.1",
     "Flask-Limiter",
+    "marshmallow>=3.13.0",
     "webargs",
     "SQLAlchemy",
     "pdf2image",


### PR DESCRIPTION
This PR cleans up some deprecation warnings by updating some dependencies:

- Marshmallow gets a new minimum version due to renaming of the webargs `missing` argument to `load_default`
- Flask-Caching also gets a minimum version and the default file system cache name is changed
- The SQLAlchemy GUID type gets the `cache_ok` attribute
- OpenCV is installed with pip rather than apt