### PR TITLE
Speed up relationship lookup

### DIFF
--- a/gramps_webapi/api/resources/relations.py
+++ b/gramps_webapi/api/resources/relations.py
@@ -30,7 +30,7 @@ from ..util import use_args
 from ..util import get_db_handle, get_locale_for_language
 from . import ProtectedResource
 from .emit import GrampsJSONEncoder
-from .util import get_person_by_handle
+from .util import get_one_relationship, get_person_by_handle
 
 
 class RelationResource(ProtectedResource, GrampsJSONEncoder):
@@ -55,11 +55,12 @@ class RelationResource(ProtectedResource, GrampsJSONEncoder):
             abort(404)
 
         locale = get_locale_for_language(args["locale"], default=True)
-        calc = get_relationship_calculator(reinit=True, clocale=locale)
-        calc.set_depth(args["depth"])
-
-        data = calc.get_one_relationship(
-            db_handle, person1, person2, extra_info=True, olocale=locale
+        data = get_one_relationship(
+            db_handle=db_handle,
+            person1=person1,
+            person2=person2,
+            depth=args["depth"],
+            locale=locale,
         )
         return self.response(
             200,

--- a/gramps_webapi/api/resources/util.py
+++ b/gramps_webapi/api/resources/util.py
@@ -53,6 +53,7 @@ from gramps.gen.lib import (
 )
 from gramps.gen.lib.primaryobj import BasicPrimaryObject as GrampsObject
 from gramps.gen.lib.serialize import from_json, to_json
+from gramps.gen.relationship import get_relationship_calculator
 from gramps.gen.soundex import soundex
 from gramps.gen.utils.db import (
     get_birth_or_fallback,
@@ -1102,3 +1103,27 @@ def get_missing_media_file_handles(
     objects = [db_handle.get_media_from_handle(handle) for handle in handles]
     objects_missing = filter_missing_files(objects)
     return [obj.handle for obj in objects_missing]
+
+
+def get_one_relationship(
+    db_handle: DbReadBase,
+    person1: Person,
+    person2: Person,
+    depth: int,
+    locale: GrampsLocale = glocale,
+) -> Tuple[str, int, int]:
+    """Get a relationship string and the number of generations between the people."""
+    calc = get_relationship_calculator(reinit=True, clocale=locale)
+    # the relationship calculation can be slow when depth is set to a large value
+    # even when the relationship path is short. To avoid this, we are iterating
+    # over depth values and only continue when no path is found.
+    for _depth in sorted({3, 10, depth}):
+        if _depth > depth:
+            break
+        calc.set_depth(_depth)
+        rel_string, dist_orig, dist_other = calc.get_one_relationship(
+            db_handle, person1, person2, extra_info=True, olocale=locale
+        )
+        if dist_orig > -1:
+            break
+    return rel_string, dist_orig, dist_other

--- a/gramps_webapi/api/resources/util.py
+++ b/gramps_webapi/api/resources/util.py
@@ -1116,14 +1116,15 @@ def get_one_relationship(
     calc = get_relationship_calculator(reinit=True, clocale=locale)
     # the relationship calculation can be slow when depth is set to a large value
     # even when the relationship path is short. To avoid this, we are iterating
-    # over depth values and only continue when no path is found.
-    for _depth in sorted({3, 10, depth}):
-        if _depth > depth:
-            break
-        calc.set_depth(_depth)
+    # trying once with depth = 5
+    if depth > 5:
+        calc.set_depth(5)
         rel_string, dist_orig, dist_other = calc.get_one_relationship(
             db_handle, person1, person2, extra_info=True, olocale=locale
         )
         if dist_orig > -1:
-            break
-    return rel_string, dist_orig, dist_other
+            return rel_string, dist_orig, dist_other
+    calc.set_depth(depth)
+    return calc.get_one_relationship(
+        db_handle, person1, person2, extra_info=True, olocale=locale
+    )


### PR DESCRIPTION
This fixes #282.

Since the Gramps function can be very slow for large number of generations even if the relationship path is short, I now implemented a simple workaoround: run the function first for 5 generations and only run again if no path is found. This way, most relationships will return much faster.