### PR TITLE
Use celery for background task (fixes #329)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: [3.8, 3.9, '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,4 +29,4 @@ jobs:
           pip list
       - name: Test with pytest
         run: |
-          pytest tests/test_endpoints/test_importers.py
+          pytest tests/test_endpoints/test_importers.py -s

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,4 +28,4 @@ jobs:
           pip install .
           pip list
       - name: Test with pytest
-        run: pytest tests/test_endpoints/test_importers.py tests/test_endpoints/test_tasks.py tests/test_endpoints/test_user.py tests/test_endpoints/test_config.py -s
+        run: pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,4 +28,4 @@ jobs:
           pip install .
           pip list
       - name: Test with pytest
-        run: pytest tests/test_endpoints/test_importers.py tests/test_endpoints/test_tasks.py tests/test_endpoints/test_user.py -s
+        run: pytest tests/test_endpoints/test_importers.py tests/test_endpoints/test_tasks.py tests/test_endpoints/test_user.py tests/test_endpoints/test_config.py -s

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version: [3.8, 3.9, '3.10']
@@ -28,5 +28,4 @@ jobs:
           pip install .
           pip list
       - name: Test with pytest
-        run: |
-          pytest tests/test_endpoints/test_importers.py -s
+        run: pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,4 +28,4 @@ jobs:
           pip install .
           pip list
       - name: Test with pytest
-        run: pytest tests/test_endpoints/test_importers.py -s
+        run: pytest tests/test_endpoints/test_importers.py tests/test_endpoints/test_tasks.py tests/test_endpoints/test_user.py -s

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip wheel
-          pip install pycairo PyGObject pytest PyYAML jsonschema pyICU opencv-python
+          pip install pycairo PyGObject pytest PyYAML jsonschema pyICU opencv-python celery[pytest]
           python -m pip install git+https://github.com/gramps-project/gramps#egg=gramps
           pip install .
           pip list

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,4 +29,4 @@ jobs:
           pip list
       - name: Test with pytest
         run: |
-          pytest
+          pytest tests/test_endpoints/test_importers.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, '3.10']
+        python-version: [3.8, 3.9, '3.10']
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,4 +28,4 @@ jobs:
           pip install .
           pip list
       - name: Test with pytest
-        run: pytest
+        run: pytest tests/test_endpoints/test_importers.py -s

--- a/gramps_webapi/api/__init__.py
+++ b/gramps_webapi/api/__init__.py
@@ -64,6 +64,7 @@ from .resources.repositories import RepositoriesResource, RepositoryResource
 from .resources.search import SearchResource
 from .resources.sources import SourceResource, SourcesResource
 from .resources.tags import TagResource, TagsResource
+from .resources.tasks import TaskResource
 from .resources.timeline import (
     FamilyTimelineResource,
     PersonTimelineResource,
@@ -278,6 +279,13 @@ register_endpt(
     ConfigResource,
     "/config/<string:key>/",
     "config",
+)
+
+# Tasks
+register_endpt(
+    TaskResource,
+    "/tasks/<string:task_id>",
+    "task",
 )
 
 # Media files

--- a/gramps_webapi/api/resources/importers.py
+++ b/gramps_webapi/api/resources/importers.py
@@ -35,7 +35,7 @@ from webargs import fields
 
 from ...auth.const import PERM_IMPORT_FILE
 from ..auth import require_permissions
-from ..tasks import search_reindex_full
+from ..tasks import make_task_response, run_task, search_reindex_full
 from ..util import get_db_handle, use_args
 from . import ProtectedResource
 from .emit import GrampsJSONEncoder
@@ -121,5 +121,7 @@ class ImporterFileResource(ProtectedResource):
         if not importers:
             abort(HTTPStatus.NOT_FOUND)
         run_import(db_handle, request.stream, extension.lower())
-        search_reindex_full()
+        task = run_task(search_reindex_full)
+        if task:
+            return make_task_response(task)
         return Response(status=201)

--- a/gramps_webapi/api/resources/importers.py
+++ b/gramps_webapi/api/resources/importers.py
@@ -20,65 +20,20 @@
 
 """Importers Plugin API resource."""
 
-import os
 import tempfile
-import uuid
 from http import HTTPStatus
-from typing import IO, Any, Dict
+from typing import Any, Dict
 
 from flask import Response, abort, request
-from gramps.gen.const import GRAMPS_LOCALE as glocale
-from gramps.gen.db.base import DbReadBase
-from gramps.gen.plug import BasePluginManager
-from gramps.gen.user import User
 from webargs import fields
 
 from ...auth.const import PERM_IMPORT_FILE
 from ..auth import require_permissions
-from ..tasks import make_task_response, run_task, search_reindex_full
+from ..tasks import import_file, make_task_response, run_task
 from ..util import get_db_handle, use_args
 from . import ProtectedResource
 from .emit import GrampsJSONEncoder
-
-
-# list of importers (by file extension) that are not allowed
-DISABLED_IMPORTERS = ["gpkg"]
-
-
-def get_importers(extension: str = None):
-    """Extract and return list of importers."""
-    importers = []
-    plugin_manager = BasePluginManager.get_instance()
-    for plugin in plugin_manager.get_import_plugins():
-        if extension is not None and extension != plugin.get_extension():
-            continue
-        if extension in DISABLED_IMPORTERS:
-            continue
-        importer = {
-            "name": plugin.get_name(),
-            "description": plugin.get_description(),
-            "extension": plugin.get_extension(),
-            "module": plugin.get_module_name(),
-        }
-        importers.append(importer)
-    return importers
-
-
-def run_import(db_handle: DbReadBase, file_obj: IO[bytes], extension: str) -> None:
-    """Generate the import."""
-    tmp_dir = tempfile.gettempdir()
-    file_name = os.path.join(tmp_dir, f"{uuid.uuid4()}.{extension}")
-    plugin_manager = BasePluginManager.get_instance()
-    for plugin in plugin_manager.get_import_plugins():
-        if extension == plugin.get_extension():
-            import_function = plugin.get_import_function()
-            with open(file_name, "wb") as f:
-                f.write(file_obj.read())
-            result = import_function(db_handle, file_name, User())
-            os.remove(file_name)
-            if not result:
-                abort(500)
-            return
+from .util import get_importers
 
 
 class ImportersResource(ProtectedResource, GrampsJSONEncoder):
@@ -116,12 +71,19 @@ class ImporterFileResource(ProtectedResource):
     def post(self, args: Dict, extension: str) -> Response:
         """Import file."""
         require_permissions([PERM_IMPORT_FILE])
-        db_handle = get_db_handle()
+        request_stream = request.stream
+        with tempfile.NamedTemporaryFile(delete=False) as ftmp:
+            ftmp.write(request_stream.read())
+            tmp_file_name = ftmp.name
         importers = get_importers(extension.lower())
         if not importers:
             abort(HTTPStatus.NOT_FOUND)
-        run_import(db_handle, request.stream, extension.lower())
-        task = run_task(search_reindex_full)
+        task = run_task(
+            import_file,
+            file_name=tmp_file_name,
+            extension=extension.lower(),
+            delete=True,
+        )
         if task:
             return make_task_response(task)
         return Response(status=201)

--- a/gramps_webapi/api/resources/tasks.py
+++ b/gramps_webapi/api/resources/tasks.py
@@ -1,0 +1,38 @@
+#
+# Gramps Web API - A RESTful API for the Gramps genealogy program
+#
+# Copyright (C) 2023      David Straub
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+"""Background task resources."""
+
+from http import HTTPStatus
+
+from celery.result import AsyncResult
+from flask import abort
+
+from . import ProtectedResource
+
+
+class TaskResource(ProtectedResource):
+    """Resource for a single task."""
+
+    def get(self, task_id: str):
+        """Get info about a task."""
+        task = AsyncResult(task_id)
+        if task is None:
+            abort(HTTPStatus.NOT_FOUND)
+        return {"state": task.state, "info": str(task.info)}

--- a/gramps_webapi/api/tasks.py
+++ b/gramps_webapi/api/tasks.py
@@ -33,7 +33,8 @@ from .util import get_config, send_email
 def run_task(task: Callable, **kwargs) -> Optional[AsyncResult]:
     """Send a task to the task queue or run immediately if no queue set up."""
     if not current_app.config["CELERY_CONFIG"]:
-        return task(**kwargs)
+        with current_app.app_context():
+            return task(**kwargs)
     return task.delay(**kwargs)
 
 
@@ -78,7 +79,7 @@ def send_email_new_user(username: str, fullname: str, email: str):
         send_email(subject=subject, body=body, to=emails)
 
 
-@shared_task()
+# @shared_task()
 def search_reindex_full() -> None:
     """Rebuild the search index."""
     indexer = current_app.config["SEARCH_INDEXER"]

--- a/gramps_webapi/api/tasks.py
+++ b/gramps_webapi/api/tasks.py
@@ -1,7 +1,7 @@
 #
 # Gramps Web API - A RESTful API for the Gramps genealogy program
 #
-# Copyright (C) 2021-2022      David Straub
+# Copyright (C) 2021-2023      David Straub
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -20,12 +20,14 @@
 
 from gettext import gettext as _
 
+from celery import shared_task
 from flask import abort, current_app
 
 from .emails import email_confirm_email, email_new_user, email_reset_pw
 from .util import get_config, send_email
 
 
+@shared_task()
 def send_email_reset_password(email: str, token: str):
     """Send an email for password reset."""
     base_url = get_config("BASE_URL").rstrip("/")
@@ -34,6 +36,7 @@ def send_email_reset_password(email: str, token: str):
     send_email(subject=subject, body=body, to=[email])
 
 
+@shared_task()
 def send_email_confirm_email(email: str, token: str):
     """Send an email to confirm an e-mail address."""
     base_url = get_config("BASE_URL").rstrip("/")
@@ -42,6 +45,7 @@ def send_email_confirm_email(email: str, token: str):
     send_email(subject=subject, body=body, to=[email])
 
 
+@shared_task()
 def send_email_new_user(username: str, fullname: str, email: str):
     """Send an email to owners to notify of a new registered user."""
     base_url = get_config("BASE_URL").rstrip("/")
@@ -57,6 +61,7 @@ def send_email_new_user(username: str, fullname: str, email: str):
         send_email(subject=subject, body=body, to=emails)
 
 
+@shared_task()
 def search_reindex_full() -> None:
     """Rebuild the search index."""
     indexer = current_app.config["SEARCH_INDEXER"]

--- a/gramps_webapi/api/tasks.py
+++ b/gramps_webapi/api/tasks.py
@@ -82,9 +82,7 @@ def send_email_new_user(username: str, fullname: str, email: str):
 @shared_task()
 def search_reindex_full() -> None:
     """Rebuild the search index."""
-    print(current_app)
     indexer = current_app.config["SEARCH_INDEXER"]
-    print(current_app.config["DB_MANAGER"].path)
     db = current_app.config["DB_MANAGER"].get_db().db
     try:
         indexer.reindex_full(db)

--- a/gramps_webapi/api/tasks.py
+++ b/gramps_webapi/api/tasks.py
@@ -79,10 +79,12 @@ def send_email_new_user(username: str, fullname: str, email: str):
         send_email(subject=subject, body=body, to=emails)
 
 
-# @shared_task()
+@shared_task()
 def search_reindex_full() -> None:
     """Rebuild the search index."""
+    print(current_app)
     indexer = current_app.config["SEARCH_INDEXER"]
+    print(current_app.config["DB_MANAGER"].path)
     db = current_app.config["DB_MANAGER"].get_db().db
     try:
         indexer.reindex_full(db)

--- a/gramps_webapi/app.py
+++ b/gramps_webapi/app.py
@@ -59,6 +59,9 @@ def create_app(
     if os.getenv(ENV_CONFIG_FILE):
         app.config.from_envvar(ENV_CONFIG_FILE)
 
+    # use prefixed environment variables if exist
+    app.config.from_prefixed_env(prefix="GRAMPSWEB")
+
     # if tree is missing, try to get it from the env or fail
     app.config["TREE"] = app.config.get("TREE") or os.getenv("TREE")
     if not app.config.get("TREE"):

--- a/gramps_webapi/app.py
+++ b/gramps_webapi/app.py
@@ -36,6 +36,7 @@ from .auth import SQLAuth
 from .config import DefaultConfig, DefaultConfigJWT
 from .const import API_PREFIX, ENV_CONFIG_FILE
 from .dbmanager import WebDbManager
+from .util.celery import create_celery
 
 
 def create_app(
@@ -150,6 +151,9 @@ def create_app(
     # register the API blueprint
     app.register_blueprint(api_blueprint)
     limiter.init_app(app)
+
+    # instantiate celery
+    create_celery(app)
 
     # close DB after every request
     @app.teardown_appcontext

--- a/gramps_webapi/celery.py
+++ b/gramps_webapi/celery.py
@@ -1,0 +1,7 @@
+"""Celery task scheduler."""
+
+from .app import create_app
+from .util.celery import make_celery
+
+
+celery = make_celery(app=create_app())

--- a/gramps_webapi/celery.py
+++ b/gramps_webapi/celery.py
@@ -1,7 +1,7 @@
 """Celery task scheduler."""
 
 from .app import create_app
-from .util.celery import make_celery
+from .util.celery import create_celery
 
 
-celery = make_celery(app=create_app())
+celery = create_celery(app=create_app())

--- a/gramps_webapi/config.py
+++ b/gramps_webapi/config.py
@@ -21,6 +21,7 @@
 
 import datetime
 import os
+from typing import Dict
 
 
 class DefaultConfig(object):
@@ -44,6 +45,7 @@ class DefaultConfig(object):
     }
     POSTGRES_USER = None
     POSTGRES_PASSWORD = None
+    CELERY_CONFIG: Dict[str, str] = {}
 
 
 class DefaultConfigJWT(object):

--- a/gramps_webapi/const.py
+++ b/gramps_webapi/const.py
@@ -170,3 +170,6 @@ LOCALE_MAP = {
     "uk": "uk_UA",
     "vi": "vi_VN",
 }
+
+# list of importers (by file extension) that are not allowed
+DISABLED_IMPORTERS = ["gpkg"]

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -416,6 +416,8 @@ paths:
       responses:
         201:
           description: "OK: e-mail successfully sent."
+        202:
+          description: "Accepted: e-mail will be sent in the background."
         404:
           description: "Not found: user does not exist or has no e-mail address."
         422:
@@ -501,6 +503,32 @@ paths:
           description: "Forbidden: missing authorization."
         405:
           description: "Method Not Allowed: No authorization provider configured."
+
+##############################################################################
+# Endpoint - Tasks
+##############################################################################
+
+  /tasks/{task_id}:
+    parameters:
+      - name: task_id
+        in: path
+        required: true
+        type: string
+        description: "The task ID."
+    get:
+      tags:
+      - tasks
+      summary: "Return information about a task."
+      operationId: getTask
+      security:
+        - Bearer: []
+      responses:
+        200:
+          description: "OK: Successful operation."
+        401:
+          description: "Unauthorized: Missing authorization header."
+        422:
+          description: "Unprocessable Entity: Invalid token."
 
 ##############################################################################
 # Endpoint - Config
@@ -6090,6 +6118,8 @@ paths:
       responses:
         201:
           description: "OK: resource created."
+        202:
+          description: "Accepted: file will be imported in the background."
         401:
           description: "Unauthorized: Missing authorization header."
         404:

--- a/gramps_webapi/util/celery.py
+++ b/gramps_webapi/util/celery.py
@@ -14,7 +14,10 @@ def create_celery(app):
         """Celery task which is aware of the flask app context."""
 
         def __call__(self, *args, **kwargs):
-            return self.run(*args, **kwargs)
+            if self.request.called_directly:
+                return self.run(*args, **kwargs)
+            with app.app_context():
+                return self.run(*args, **kwargs)
 
     celery.Task = ContextTask
     return celery

--- a/gramps_webapi/util/celery.py
+++ b/gramps_webapi/util/celery.py
@@ -4,9 +4,10 @@ from celery import Task
 from celery import current_app as current_celery_app
 
 
-def make_celery(app):
+def create_celery(app):
     """App factory for celery."""
     celery = current_celery_app
+    celery.conf.name = app.import_name
     celery.conf.update(app.config["CELERY_CONFIG"])
 
     class ContextTask(Task):

--- a/gramps_webapi/util/celery.py
+++ b/gramps_webapi/util/celery.py
@@ -14,8 +14,7 @@ def create_celery(app):
         """Celery task which is aware of the flask app context."""
 
         def __call__(self, *args, **kwargs):
-            with app.app_context():
-                return self.run(*args, **kwargs)
+            return self.run(*args, **kwargs)
 
     celery.Task = ContextTask
     return celery

--- a/gramps_webapi/util/celery.py
+++ b/gramps_webapi/util/celery.py
@@ -1,0 +1,20 @@
+"""Utility functions for celery."""
+
+from celery import Task
+from celery import current_app as current_celery_app
+
+
+def make_celery(app):
+    """App factory for celery."""
+    celery = current_celery_app
+    celery.conf.update(app.config["CELERY_CONFIG"])
+
+    class ContextTask(Task):
+        """Celery task which is aware of the flask app context."""
+
+        def __call__(self, *args, **kwargs):
+            with app.app_context():
+                return self.run(*args, **kwargs)
+
+    celery.Task = ContextTask
+    return celery

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ flake8
 mypy
 pydocstyle
 pre-commit
+celery[pytest]

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,8 @@ REQUIREMENTS = [
     "boto3",
     "alembic",
     "celery[redis]",
+    # the following is necessary due to https://github.com/python/importlib_metadata/issues/411
+    'importlib-metadata == 4.13.0; python_version == "3.7"',
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ REQUIREMENTS = [
     "ffmpeg-python",
     "boto3",
     "alembic",
+    "celery[redis]",
 ]
 
 setup(

--- a/tests/test_endpoints/test_tasks.py
+++ b/tests/test_endpoints/test_tasks.py
@@ -1,0 +1,76 @@
+#
+# Gramps Web API - A RESTful API for the Gramps genealogy program
+#
+# Copyright (C) 2023      David Straub
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+"""Tests for the /api/tasks endpoint."""
+
+import unittest
+from unittest.mock import patch
+
+import pytest
+from gramps.cli.clidbman import CLIDbManager
+from gramps.gen.dbstate import DbState
+
+from gramps_webapi.app import create_app
+from gramps_webapi.auth.const import ROLE_GUEST, ROLE_OWNER
+from gramps_webapi.const import ENV_CONFIG_FILE, TEST_AUTH_CONFIG
+
+
+@pytest.mark.usefixtures("celery_session_app")
+@pytest.mark.usefixtures("celery_session_worker")
+class TestTask(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.name = "Test Web API"
+        cls.dbman = CLIDbManager(DbState())
+        _, _name = cls.dbman.create_new_db_cli(cls.name, dbid="sqlite")
+        with patch.dict("os.environ", {ENV_CONFIG_FILE: TEST_AUTH_CONFIG}):
+            cls.app = create_app(
+                config={
+                    "TESTING": True,
+                    "RATELIMIT_ENABLED": False,
+                    "CELERY_CONFIG": {
+                        "broker_url": "redis://",
+                        "result_backend": "redis://",
+                    },
+                }
+            )
+        cls.client = cls.app.test_client()
+        sqlauth = cls.app.config["AUTH_PROVIDER"]
+        sqlauth.create_table()
+        sqlauth.add_user(name="user", password="123", role=ROLE_GUEST)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.dbman.remove_database(cls.name)
+
+    def test_task_noauth(self):
+        rv = self.client.get("/api/tasks/nope")
+        assert rv.status_code == 401
+
+    def test_task_nonexistant(self):
+        rv = self.client.post(
+            "/api/token/", json={"username": "user", "password": "123"}
+        )
+        token = rv.json["access_token"]
+        rv = self.client.get(
+            "/api/tasks/nope",
+            headers={"Authorization": "Bearer {}".format(token)},
+        )
+        assert rv.status_code == 200
+        assert rv.json["state"] == "PENDING"


### PR DESCRIPTION
Work in progress.

- Add optional celery app
- Turn tasks into celery tasks if celery is configured
- Add `/api/task/{task_id}` endpoint for checking task status
- Tasks return 202 and the URL of the task endpoint
