### PR TITLE
Enable the running as any non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,9 @@ RUN mkdir /app/static && touch /app/static/index.html
 RUN mkdir /app/db && mkdir /app/media && mkdir /app/indexdir && mkdir /app/users
 RUN mkdir /app/thumbnail_cache
 RUN mkdir /app/tmp
-RUN mkdir -p /root/.gramps/gramps$GRAMPS_VERSION
+RUN chmod -R g=u /app
+RUN mkdir -p /data/gramps/gramps$GRAMPS_VERSION
+RUN chmod -R g=u /data
 ENV USER_DB_URI=sqlite:////app/users/users.sqlite
 ENV MEDIA_BASE_DIR=/app/media
 ENV SEARCH_INDEX_DIR=/app/indexdir
@@ -37,7 +39,7 @@ ENV STATIC_PATH=/app/static
 # install PostgreSQL addon
 RUN wget https://github.com/gramps-project/addons/archive/refs/heads/master.zip \
     && unzip -p master.zip addons-master/gramps$GRAMPS_VERSION/download/PostgreSQL.addon.tgz | \
-    tar -xvz -C /root/.gramps/gramps$GRAMPS_VERSION/plugins && rm master.zip
+    tar -xvz -C /data/gramps/gramps$GRAMPS_VERSION/plugins && rm master.zip
 
 # install OpenCV
 RUN python3 -m pip install --no-cache-dir --extra-index-url https://www.piwheels.org/simple \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ ENV LANG en_US.utf8
 ENV LC_ALL en_US.utf8
 
 ENV GRAMPS_API_CONFIG=/app/config/config.cfg
+ENV GRAMPSHOME=/data
 
 # create directories
 RUN mkdir /app/src &&  mkdir /app/config && touch /app/config/config.cfg

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN mkdir /app/db && mkdir /app/media && mkdir /app/indexdir && mkdir /app/users
 RUN mkdir /app/thumbnail_cache
 RUN mkdir /app/tmp
 RUN chmod -R g=u /app
-RUN mkdir -p /data/gramps/gramps$GRAMPS_VERSION
+RUN mkdir -p /data/gramps/gramps$GRAMPS_VERSION/plugins
 RUN chmod -R g=u /data
 ENV USER_DB_URI=sqlite:////app/users/users.sqlite
 ENV MEDIA_BASE_DIR=/app/media


### PR DESCRIPTION
Good security practice is to run as non-root. Some kubernetes environments such as Openshift/OKD don't allow root by default. The [documentation](https://docs.okd.io/4.11/openshift_images/create-images.html) gives an explanation of how to do this. I have implemented it here for the webapi.