### PR TITLE
New endpoint to trigger search reindex

### DIFF
--- a/gramps_webapi/api/__init__.py
+++ b/gramps_webapi/api/__init__.py
@@ -61,7 +61,7 @@ from .resources.places import PlaceResource, PlacesResource
 from .resources.relations import RelationResource, RelationsResource
 from .resources.reports import ReportFileResource, ReportResource, ReportsResource
 from .resources.repositories import RepositoriesResource, RepositoryResource
-from .resources.search import SearchResource
+from .resources.search import SearchIndexResource, SearchResource
 from .resources.sources import SourceResource, SourcesResource
 from .resources.tags import TagResource, TagsResource
 from .resources.tasks import TaskResource
@@ -268,6 +268,7 @@ register_endpt(
 )
 # Search
 register_endpt(SearchResource, "/search/", "search")
+register_endpt(SearchIndexResource, "/search/index/", "search_index")
 
 # Config
 register_endpt(

--- a/gramps_webapi/api/tasks.py
+++ b/gramps_webapi/api/tasks.py
@@ -98,6 +98,17 @@ def search_reindex_full() -> None:
 
 
 @shared_task()
+def search_reindex_incremental() -> None:
+    """Run an incremental reindex of the search index."""
+    indexer = current_app.config["SEARCH_INDEXER"]
+    db = current_app.config["DB_MANAGER"].get_db().db
+    try:
+        indexer.search_reindex_incremental(db)
+    finally:
+        db.close()
+
+
+@shared_task()
 def import_file(file_name: str, extension: str, delete: bool = True):
     """Import a file."""
     db_handle = current_app.config["DB_MANAGER"].get_db().db

--- a/gramps_webapi/auth/const.py
+++ b/gramps_webapi/auth/const.py
@@ -43,6 +43,7 @@ PERM_DEL_OBJ = "DeleteObject"
 PERM_IMPORT_FILE = "ImportFile"
 PERM_VIEW_SETTINGS = "ViewSettings"
 PERM_EDIT_SETTINGS = "EditSettings"
+PERM_TRIGGER_REINDEX = "TriggerReindex"
 
 PERMISSIONS = {
     ROLE_OWNER: {
@@ -59,6 +60,7 @@ PERMISSIONS = {
         PERM_IMPORT_FILE,
         PERM_VIEW_SETTINGS,
         PERM_EDIT_SETTINGS,
+        PERM_TRIGGER_REINDEX,
     },
     ROLE_EDITOR: {
         PERM_EDIT_OWN_USER,

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -418,6 +418,11 @@ paths:
           description: "OK: e-mail successfully sent."
         202:
           description: "Accepted: e-mail will be sent in the background."
+          schema:
+            type: object
+            properties:
+              task:
+                $ref: "#/definitions/TaskReference"
         404:
           description: "Not found: user does not exist or has no e-mail address."
         422:
@@ -5004,7 +5009,7 @@ paths:
       tags:
       - translations
       summary: "Get a translation in a specific language."
-      operationId: getTranslation
+      operationId: postTranslation
       security:
         - Bearer: []
       parameters:
@@ -5648,6 +5653,38 @@ paths:
         422:
           description: "Unprocessable Entity: Invalid or bad parameter provided."
 
+  /search/index/:
+    post:
+      tags:
+      - search
+      summary: "Trigger a reindex of the search index."
+      operationId: reindexSearch
+      security:
+        - Bearer: []
+      parameters:
+      - name: full
+        in: query
+        required: false
+        type: boolean
+        default: false
+        description: "Perform a full or incremental (default) reindex."
+      responses:
+        201:
+          description: "OK: Successful operation."
+        202:
+          description: "Accepted: reindex will be performed in the background."
+          schema:
+            type: object
+            properties:
+              task:
+                $ref: "#/definitions/TaskReference"
+        401:
+          description: "Unauthorized: Missing authorization header."
+        403:
+          description: "Unauthorized: insufficient permissions."
+        422:
+          description: "Unprocessable Entity: Invalid or bad parameter provided."
+
 
 ##############################################################################
 # Endpoint - Reports
@@ -6120,6 +6157,11 @@ paths:
           description: "OK: resource created."
         202:
           description: "Accepted: file will be imported in the background."
+          schema:
+            type: object
+            properties:
+              task:
+                $ref: "#/definitions/TaskReference"
         401:
           description: "Unauthorized: Missing authorization header."
         404:
@@ -9519,3 +9561,20 @@ definitions:
         description: "The object value supporting the fact."
         type: string
         example: "21 years, 8 months, 11 days"
+
+
+##############################################################################
+# Model - TaskReference
+##############################################################################
+
+  TaskReference:
+    type: object
+    properties:
+      href:
+        description: "The URL of the task detail endpoint."
+        type: string
+        example: "https://grampsweb.example.com/api/tasks/b9ed86ea-1c6b-400a-bb70-af9cb11bdf13"
+      id:
+        description: "The unique identifier for a task."
+        type: string
+        example: "b9ed86ea-1c6b-400a-bb70-af9cb11bdf13"


### PR DESCRIPTION
This adds a new endpoint ` /api/search/index/` that allows to trigger a search reindex, incremental or full (`?full=1`).

If configured, uses the new background task queue.