### PR TITLE
Require elevated permissions to edit name groups (#310)

### DIFF
--- a/gramps_webapi/api/resources/name_groups.py
+++ b/gramps_webapi/api/resources/name_groups.py
@@ -22,6 +22,8 @@
 from flask import Response, abort
 from gramps.gen.db.base import DbReadBase
 
+from ...auth.const import PERM_EDIT_NAME_GROUP
+from ..auth import require_permissions
 from ..util import get_db_handle
 from . import ProtectedResource
 from .emit import GrampsJSONEncoder
@@ -57,6 +59,7 @@ class NameGroupsResource(ProtectedResource, GrampsJSONEncoder):
 
     def post(self, surname: str = None, group: str = None) -> Response:
         """Set a name group mapping."""
+        require_permissions([PERM_EDIT_NAME_GROUP])
         db_handle = self.db_handle
         if surname is None or group is None or len(surname) == 0 or len(group) == 0:
             abort(400)

--- a/gramps_webapi/auth/const.py
+++ b/gramps_webapi/auth/const.py
@@ -44,6 +44,7 @@ PERM_IMPORT_FILE = "ImportFile"
 PERM_VIEW_SETTINGS = "ViewSettings"
 PERM_EDIT_SETTINGS = "EditSettings"
 PERM_TRIGGER_REINDEX = "TriggerReindex"
+PERM_EDIT_NAME_GROUP = "EditNameGroup"
 
 PERMISSIONS = {
     ROLE_OWNER: {
@@ -61,6 +62,7 @@ PERMISSIONS = {
         PERM_VIEW_SETTINGS,
         PERM_EDIT_SETTINGS,
         PERM_TRIGGER_REINDEX,
+        PERM_EDIT_NAME_GROUP,
     },
     ROLE_EDITOR: {
         PERM_EDIT_OWN_USER,
@@ -68,6 +70,7 @@ PERMISSIONS = {
         PERM_EDIT_OBJ,
         PERM_ADD_OBJ,
         PERM_DEL_OBJ,
+        PERM_EDIT_NAME_GROUP,
     },
     ROLE_CONTRIBUTOR: {
         PERM_EDIT_OWN_USER,

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -4631,6 +4631,8 @@ paths:
               $ref: "#/definitions/NameGroupMapping"
         401:
           description: "Unauthorized: Missing authorization header."
+        403:
+          description: "Unauthorized: insufficient permissions."
 
 
   /name-groups/{surname}:

--- a/tests/test_endpoints/test_name_groups.py
+++ b/tests/test_endpoints/test_name_groups.py
@@ -21,6 +21,8 @@
 
 import unittest
 
+from gramps_webapi.auth.const import ROLE_MEMBER
+
 from . import BASE_URL, get_test_client
 from .checks import check_conforms_to_schema, check_requires_token, check_success
 from .util import fetch_header
@@ -83,6 +85,12 @@ class TestNameGroupsSurnameGroup(unittest.TestCase):
         self.assertEqual(rv.status_code, 400)
         rv = self.client.post(TEST_URL + "Stephen/", headers=header)
         self.assertEqual(rv.status_code, 404)
+
+    def test_post_name_groups_surname_insufficient_authorization(self):
+        """Test adding a mapping."""
+        header = fetch_header(self.client, role=ROLE_MEMBER)
+        rv = self.client.post(TEST_URL + "Stephen/Steven", headers=header)
+        self.assertEqual(rv.status_code, 403)
 
     def test_post_name_groups_surname_add_mapping(self):
         """Test adding a mapping."""


### PR DESCRIPTION
Introduced a new permission `EditNameGroup` granted to editor and above.