### PR TITLE
Deprecate unprefixed environment variables

### DIFF
--- a/gramps_webapi/config.py
+++ b/gramps_webapi/config.py
@@ -28,16 +28,16 @@ class DefaultConfig(object):
     """Default configuration object."""
 
     PROPAGATE_EXCEPTIONS = True
-    SEARCH_INDEX_DIR = os.getenv("SEARCH_INDEX_DIR", "indexdir")
-    EMAIL_HOST = os.getenv("EMAIL_HOST", "localhost")
-    EMAIL_PORT = os.getenv("EMAIL_PORT", "465")
-    EMAIL_HOST_USER = os.getenv("EMAIL_HOST_USER", "")
-    EMAIL_HOST_PASSWORD = os.getenv("EMAIL_HOST_PASSWORD", "")
+    SEARCH_INDEX_DIR = "indexdir"
+    EMAIL_HOST = "localhost"
+    EMAIL_PORT = "465"
+    EMAIL_HOST_USER = ""
+    EMAIL_HOST_PASSWORD = ""
     EMAIL_USE_TLS = True
-    DEFAULT_FROM_EMAIL = os.getenv("DEFAULT_FROM_EMAIL", "")
-    BASE_URL = os.getenv("BASE_URL", "http://localhost/")
+    DEFAULT_FROM_EMAIL = ""
+    BASE_URL = "http://localhost/"
     CORS_EXPOSE_HEADERS = ["X-Total-Count"]
-    STATIC_PATH = os.getenv("STATIC_PATH", "static")
+    STATIC_PATH = "static"
     THUMBNAIL_CACHE_CONFIG = {
         "CACHE_TYPE": "FileSystemCache",
         "CACHE_DIR": "thumbnail_cache",


### PR DESCRIPTION
v0.5.0 introduced the new "prefixed environment" way to set _all_ config options, including nested dicts, via environment variables prefixed with `GRAMPSWEB_`, using a new feature in Flask 2.2.

This PR deprecates the old way of being able to set some (not all) of the config options via unprefixed environment variables. This is not a breaking change (yet), but the deprecated functionality is moved to a single function that can be removed eventually and issues a warning for the tie being.

The goal is to simplify the configuration handling code.