### PR TITLE
Add transliterated strings to search index (fixes #352)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ REQUIREMENTS = [
     "boto3",
     "alembic",
     "celery[redis]",
+    "Unidecode",
     # the following is necessary due to https://github.com/python/importlib_metadata/issues/411
     'importlib-metadata == 4.13.0; python_version == "3.7"',
 ]

--- a/tests/test_endpoints/test_search.py
+++ b/tests/test_endpoints/test_search.py
@@ -130,7 +130,12 @@ class TestSearch(unittest.TestCase):
     def test_get_search_expected_result_unicode(self):
         """Test expected result querying for a Unicode decoded string."""
         # 斎藤 is transliterated as Zhai Teng
-        rv = check_success(self, TEST_URL + f"?query={quote('Zhai type:person')}")
+        rv = check_success(self, TEST_URL + f"?query={quote('Zhai Teng type:person')}")
+        self.assertEqual(len(rv), 1)
+        self.assertIn("object", rv[0])
+        print(rv[0]["object"])
+        self.assertEqual(rv[0]["object"]["gramps_id"], "I0761")
+        rv = check_success(self, TEST_URL + f"?query={quote('斎藤 type:person')}")
         self.assertEqual(len(rv), 1)
         self.assertIn("object", rv[0])
         print(rv[0]["object"])
@@ -140,6 +145,11 @@ class TestSearch(unittest.TestCase):
         """Test expected result querying for a Unicode decoded string."""
         # Шестаков is transliterated as Shestakov
         rv = check_success(self, TEST_URL + f"?query={quote('Shestakov type:person')}")
+        self.assertEqual(len(rv), 1)
+        self.assertIn("object", rv[0])
+        print(rv[0]["object"])
+        self.assertEqual(rv[0]["object"]["gramps_id"], "I0972")
+        rv = check_success(self, TEST_URL + f"?query={quote('Шестаков type:person')}")
         self.assertEqual(len(rv), 1)
         self.assertIn("object", rv[0])
         print(rv[0]["object"])

--- a/tests/test_endpoints/test_search.py
+++ b/tests/test_endpoints/test_search.py
@@ -127,6 +127,24 @@ class TestSearch(unittest.TestCase):
         self.assertIn("object", rv[0])
         self.assertEqual(rv[0]["object"]["gramps_id"], "I0044")
 
+    def test_get_search_expected_result_unicode(self):
+        """Test expected result querying for a Unicode decoded string."""
+        # 斎藤 is transliterated as Zhai Teng
+        rv = check_success(self, TEST_URL + f"?query={quote('Zhai type:person')}")
+        self.assertEqual(len(rv), 1)
+        self.assertIn("object", rv[0])
+        print(rv[0]["object"])
+        self.assertEqual(rv[0]["object"]["gramps_id"], "I0761")
+
+    def test_get_search_expected_result_unicode_2(self):
+        """Test expected result querying for a Unicode decoded string."""
+        # Шестаков is transliterated as Shestakov
+        rv = check_success(self, TEST_URL + f"?query={quote('Shestakov type:person')}")
+        self.assertEqual(len(rv), 1)
+        self.assertIn("object", rv[0])
+        print(rv[0]["object"])
+        self.assertEqual(rv[0]["object"]["gramps_id"], "I0972")
+
     def test_get_search_expected_result_no_hits(self):
         """Test expected result when no hits."""
         rv = check_success(self, TEST_URL + "?query=LoremIpsumDolorSitAmet", full=True)

--- a/tests/test_endpoints/test_search.py
+++ b/tests/test_endpoints/test_search.py
@@ -130,7 +130,7 @@ class TestSearch(unittest.TestCase):
     def test_get_search_expected_result_unicode(self):
         """Test expected result querying for a Unicode decoded string."""
         # 斎藤 is transliterated as Zhai Teng
-        rv = check_success(self, TEST_URL + f"?query={quote('Zhai Teng type:person')}")
+        rv = check_success(self, TEST_URL + f"?query={quote('Zhai Teng type:person') }")
         self.assertEqual(len(rv), 1)
         self.assertIn("object", rv[0])
         print(rv[0]["object"])


### PR DESCRIPTION
This adds transliterated strings to the search index if the strings contain non-ASCII characters. This allows to search for Mr. Шестаков by searching for Shestakov, for instance. See #352.