### PR TITLE
Reports: use task queue if available, translate (fixed #351)

### DIFF
--- a/gramps_webapi/api/__init__.py
+++ b/gramps_webapi/api/__init__.py
@@ -60,7 +60,12 @@ from .resources.objects import CreateObjectsResource
 from .resources.people import PeopleResource, PersonResource
 from .resources.places import PlaceResource, PlacesResource
 from .resources.relations import RelationResource, RelationsResource
-from .resources.reports import ReportFileResource, ReportResource, ReportsResource
+from .resources.reports import (
+    ReportFileResource,
+    ReportFileResultResource,
+    ReportResource,
+    ReportsResource,
+)
 from .resources.repositories import RepositoriesResource, RepositoryResource
 from .resources.search import SearchIndexResource, SearchResource
 from .resources.sources import SourceResource, SourcesResource
@@ -202,13 +207,17 @@ register_endpt(LivingResource, "/living/<string:handle>", "living")
 register_endpt(ReportFileResource, "/reports/<string:report_id>/file", "report-file")
 register_endpt(ReportResource, "/reports/<string:report_id>", "report")
 register_endpt(ReportsResource, "/reports/", "reports")
+register_endpt(
+    ReportFileResultResource,
+    "/reports/<string:report_id>/file/processed/<string:filename>",
+    "report-file-result",
+)
 # Facts
 register_endpt(FactsResource, "/facts/", "facts")
 # Exporters
 register_endpt(
     ExporterFileResource, "/exporters/<string:extension>/file", "exporter-file"
 )
-# Exporters
 register_endpt(
     ExporterFileResultResource,
     "/exporters/<string:extension>/file/processed/<string:filename>",

--- a/gramps_webapi/api/export.py
+++ b/gramps_webapi/api/export.py
@@ -23,7 +23,6 @@
 
 import mimetypes
 import os
-import tempfile
 import uuid
 from pathlib import Path
 from typing import Dict

--- a/gramps_webapi/api/report.py
+++ b/gramps_webapi/api/report.py
@@ -1,0 +1,254 @@
+#
+# Gramps Web API - A RESTful API for the Gramps genealogy program
+#
+# Copyright (C) 2020      Christopher Horn
+# Copyright (C) 2023      David Straub
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+"""Functions for running Gramps reports."""
+
+import os
+import uuid
+from pathlib import Path
+from typing import Dict, Optional
+
+from flask import abort, current_app
+from gramps.cli.plug import CommandLineReport
+from gramps.cli.user import User
+from gramps.gen.db.base import DbReadBase
+from gramps.gen.filters import reload_custom_filters
+from gramps.gen.plug import BasePluginManager
+from gramps.gen.plug.docgen import PaperStyle
+from gramps.gen.plug.report import (
+    CATEGORY_BOOK,
+    CATEGORY_DRAW,
+    CATEGORY_GRAPHVIZ,
+    CATEGORY_TEXT,
+    CATEGORY_TREE,
+)
+from gramps.gen.utils.grampslocale import GrampsLocale
+from gramps.gen.utils.resourcepath import ResourcePath
+
+from ..const import MIME_TYPES, REPORT_DEFAULTS, REPORT_FILTERS
+
+_EXTENSION_MAP = {".gvpdf": ".pdf", ".gspdf": ".pdf"}
+
+
+def get_report_profile(
+    db_handle: DbReadBase, plugin_manager: BasePluginManager, report_data
+):
+    """Extract and return report attributes and options."""
+    module = plugin_manager.load_plugin(report_data)
+    option_class = getattr(module, report_data.optionclass)
+    report = CommandLineReport(
+        db_handle, report_data.name, report_data.category, option_class, {}
+    )
+    options_help = report.options_help
+    if REPORT_FILTERS:
+        for report_type in REPORT_FILTERS:
+            for item in options_help["off"][2]:
+                if item[: len(report_type)] == report_type:
+                    del options_help["off"][2][options_help["off"][2].index(item)]
+                    break
+    return {
+        "authors": report_data.authors,
+        "authors_email": report_data.authors_email,
+        "category": report_data.category,
+        "description": report_data.description,
+        "id": report_data.id,
+        "name": report_data.name,
+        "options_dict": report.options_dict,
+        "options_help": options_help,
+        "report_modes": report_data.report_modes,
+        "version": report_data.version,
+    }
+
+
+def get_reports(db_handle: DbReadBase, report_id: str = None):
+    """Extract and return report attributes and options."""
+    reload_custom_filters()
+    plugin_manager = BasePluginManager.get_instance()
+    reports = []
+    for report_data in plugin_manager.get_reg_reports(gui=False):
+        if report_id is not None and report_data.id != report_id:
+            continue
+        if report_data.category not in REPORT_DEFAULTS:
+            continue
+        report = get_report_profile(db_handle, plugin_manager, report_data)
+        reports.append(report)
+    return reports
+
+
+def check_report_id_exists(report_id: str) -> bool:
+    """Check if a report ID exists."""
+    reload_custom_filters()
+    plugin_manager = BasePluginManager.get_instance()
+    for report_data in plugin_manager.get_reg_reports(gui=False):
+        if report_data.id == report_id:
+            return True
+    return False
+
+
+def cl_report_new(
+    database,
+    name,
+    category,
+    report_class,
+    options_class,
+    options_str_dict,
+    language: Optional[str] = None,
+):
+    """Run the selected report.
+
+    Derived from gramps.cli.plug.cl_report.
+    """
+    clr = CommandLineReport(database, name, category, options_class, options_str_dict)
+    if category in [CATEGORY_TEXT, CATEGORY_DRAW, CATEGORY_BOOK]:
+        if clr.doc_options:
+            clr.option_class.handler.doc = clr.format(
+                clr.selected_style,
+                PaperStyle(
+                    clr.paper,
+                    clr.orien,
+                    clr.marginl,
+                    clr.marginr,
+                    clr.margint,
+                    clr.marginb,
+                ),
+                clr.doc_options,
+            )
+        else:
+            clr.option_class.handler.doc = clr.format(
+                clr.selected_style,
+                PaperStyle(
+                    clr.paper,
+                    clr.orien,
+                    clr.marginl,
+                    clr.marginr,
+                    clr.margint,
+                    clr.marginb,
+                ),
+            )
+    elif category in [CATEGORY_GRAPHVIZ, CATEGORY_TREE]:
+        clr.option_class.handler.doc = clr.format(
+            clr.option_class,
+            PaperStyle(
+                clr.paper,
+                clr.orien,
+                clr.marginl,
+                clr.marginr,
+                clr.margint,
+                clr.marginb,
+            ),
+        )
+    if clr.css_filename is not None and hasattr(
+        clr.option_class.handler.doc, "set_css_filename"
+    ):
+        clr.option_class.handler.doc.set_css_filename(clr.css_filename)
+    my_report = report_class(database, clr.option_class, User())
+    my_report.set_locale(language or GrampsLocale.DEFAULT_TRANSLATION_STR)
+    my_report.doc.init()
+    my_report.begin_report()
+    my_report.write_report()
+    my_report.end_report()
+    return clr
+
+
+def run_report(
+    db_handle: DbReadBase,
+    report_id: str,
+    report_options: Dict,
+    allow_file: bool = False,
+    language: Optional[str] = None,
+):
+    """Generate the report."""
+    if "off" in report_options and report_options["off"] in REPORT_FILTERS:
+        abort(422)
+    _resources = ResourcePath()
+    os.environ["GRAMPS_RESOURCES"] = str(Path(_resources.data_dir).parent)
+    reload_custom_filters()
+    plugin_manager = BasePluginManager.get_instance()
+    for report_data in plugin_manager.get_reg_reports(gui=False):
+        if report_data.id == report_id:
+            if report_data.category not in REPORT_DEFAULTS:
+                abort(404)
+            if "off" not in report_options:
+                report_options["off"] = REPORT_DEFAULTS[report_data.category]
+            file_type = "." + report_options["off"]
+            file_type = _EXTENSION_MAP.get(file_type) or file_type
+            if file_type not in MIME_TYPES:
+                current_app.logger.error(f"Cannot find {file_type} in MIME_TYPES")
+                abort(500)
+            report_path = current_app.config.get("REPORT_DIR")
+            os.makedirs(report_path, exist_ok=True)
+            file_name = f"{uuid.uuid4()}{file_type}"
+            report_options["of"] = os.path.join(report_path, file_name)
+            report_profile = get_report_profile(db_handle, plugin_manager, report_data)
+            validate_options(report_profile, report_options, allow_file=allow_file)
+            module = plugin_manager.load_plugin(report_data)
+            option_class = getattr(module, report_data.optionclass)
+            report_class = getattr(module, report_data.reportclass)
+            cl_report_new(
+                db_handle,
+                report_data.name,
+                report_data.category,
+                report_class,
+                option_class,
+                report_options,
+                language=language,
+            )
+            if (
+                file_type == ".dot"
+                and not os.path.isfile(report_options["of"])
+                and os.path.isfile(report_options["of"] + ".gv")
+            ):
+                file_type = ".gv"
+                file_name = f"{file_name}.gv"
+            return file_name, file_type
+    abort(404)
+
+
+def validate_options(report: Dict, report_options: Dict, allow_file: bool = False):
+    """Check validity of provided report options."""
+    if report["id"] == "familylines_graph":
+        if "gidlist" not in report_options or not report_options["gidlist"]:
+            abort(422)
+    for option in report_options:
+        if option not in report["options_dict"]:
+            abort(422)
+        if isinstance(report["options_help"][option][2], type([])):
+            option_list = []
+            for item in report["options_help"][option][2]:
+                # Some option specs include a comment part after a tab, e.g. to give
+                # the name of a family associated with a family ID. It's the part
+                # before the tab that's a valid value.
+                # Some tab-separated specs also have a colon before the tab.
+                option_list.append(item.split("\t")[0].rstrip(":"))
+            if report_options[option] not in option_list:
+                abort(422)
+            continue
+        if not isinstance(report_options[option], str):
+            abort(422)
+        if "A number" in report["options_help"][option][2]:
+            try:
+                float(report_options[option])
+            except ValueError:
+                abort(422)
+        if "Size in cm" in report["options_help"][option][2]:
+            try:
+                float(report_options[option])
+            except ValueError:
+                abort(422)

--- a/gramps_webapi/api/resources/exporters.py
+++ b/gramps_webapi/api/resources/exporters.py
@@ -200,11 +200,13 @@ class ExporterFileResultResource(ProtectedResource, GrampsJSONEncoder):
 
         file_type = match.group(2)
         file_path = os.path.join(export_path, filename)
+        if not os.path.isfile(file_path):
+            abort(404)
+        date_lastmod = time.localtime(os.path.getmtime(file_path))
         buffer = get_buffer_for_file(file_path, delete=True)
         mime_type = "application/octet-stream"
         if file_type != ".pl" and file_type in mimetypes.types_map:
             mime_type = mimetypes.types_map[file_type]
-        date_lastmod = time.localtime(os.path.getmtime(file_path))
         date_str = time.strftime("%Y%m%d%H%M%S", date_lastmod)
         download_name = f"gramps-web-export-{date_str}{file_type}"
         return send_file(buffer, mimetype=mime_type, download_name=download_name)

--- a/gramps_webapi/api/resources/reports.py
+++ b/gramps_webapi/api/resources/reports.py
@@ -20,153 +20,28 @@
 """Reports Plugin API resource."""
 
 import json
+import mimetypes
 import os
-import uuid
-from pathlib import Path
+import re
+import time
 from typing import Dict
 
-from flask import Response, abort, current_app, send_file
-from gramps.cli.plug import CommandLineReport, cl_report
-from gramps.gen.db.base import DbReadBase
-from gramps.gen.filters import reload_custom_filters
-from gramps.gen.plug import BasePluginManager
-from gramps.gen.utils.resourcepath import ResourcePath
+from flask import Response, abort, current_app, jsonify, send_file
 from webargs import fields, validate
 
-from ...const import MIME_TYPES, REPORT_DEFAULTS, REPORT_FILTERS
-from ..util import get_buffer_for_file, get_db_handle, use_args
+from ...auth.const import PERM_VIEW_PRIVATE
+from ...const import MIME_TYPES
+from ..auth import has_permissions
+from ..report import check_report_id_exists, get_reports, run_report
+from ..tasks import AsyncResult, generate_report, make_task_response, run_task
+from ..util import (
+    get_buffer_for_file,
+    get_db_handle,
+    get_tree_from_jwt,
+    use_args,
+)
 from . import ProtectedResource
 from .emit import GrampsJSONEncoder
-
-_EXTENSION_MAP = {".gvpdf": ".pdf", ".gspdf": ".pdf"}
-
-
-def get_report_profile(
-    db_handle: DbReadBase, plugin_manager: BasePluginManager, report_data
-):
-    """Extract and return report attributes and options."""
-    module = plugin_manager.load_plugin(report_data)
-    option_class = getattr(module, report_data.optionclass)
-    report = CommandLineReport(
-        db_handle, report_data.name, report_data.category, option_class, {}
-    )
-    icondir = report_data.icondir or ""
-    options_help = report.options_help
-    if REPORT_FILTERS:
-        for report_type in REPORT_FILTERS:
-            for item in options_help["off"][2]:
-                if item[: len(report_type)] == report_type:
-                    del options_help["off"][2][options_help["off"][2].index(item)]
-                    break
-    return {
-        "authors": report_data.authors,
-        "authors_email": report_data.authors_email,
-        "category": report_data.category,
-        "description": report_data.description,
-        "id": report_data.id,
-        "name": report_data.name,
-        "options_dict": report.options_dict,
-        "options_help": options_help,
-        "report_modes": report_data.report_modes,
-        "version": report_data.version,
-    }
-
-
-def get_reports(db_handle: DbReadBase, report_id: str = None):
-    """Extract and return report attributes and options."""
-    reload_custom_filters()
-    plugin_manager = BasePluginManager.get_instance()
-    reports = []
-    for report_data in plugin_manager.get_reg_reports(gui=False):
-        if report_id is not None and report_data.id != report_id:
-            continue
-        if report_data.category not in REPORT_DEFAULTS:
-            continue
-        report = get_report_profile(db_handle, plugin_manager, report_data)
-        reports.append(report)
-    return reports
-
-
-def run_report(
-    db_handle: DbReadBase,
-    report_id: str,
-    report_options: Dict,
-    allow_file: bool = False,
-):
-    """Generate the report."""
-    if "off" in report_options and report_options["off"] in REPORT_FILTERS:
-        abort(422)
-    _resources = ResourcePath()
-    os.environ["GRAMPS_RESOURCES"] = str(Path(_resources.data_dir).parent)
-    reload_custom_filters()
-    plugin_manager = BasePluginManager.get_instance()
-    for report_data in plugin_manager.get_reg_reports(gui=False):
-        if report_data.id == report_id:
-            if report_data.category not in REPORT_DEFAULTS:
-                abort(404)
-            if "off" not in report_options:
-                report_options["off"] = REPORT_DEFAULTS[report_data.category]
-            file_type = "." + report_options["off"]
-            file_type = _EXTENSION_MAP.get(file_type) or file_type
-            if file_type not in MIME_TYPES:
-                current_app.logger.error(
-                    "Can not find {} in MIME_TYPES".format(file_type)
-                )
-                abort(500)
-            report_path = current_app.config.get("REPORT_DIR")
-            os.makedirs(report_path, exist_ok=True)
-            file_name = os.path.join(
-                report_path, "{}{}".format(uuid.uuid4(), file_type)
-            )
-            report_options["of"] = file_name
-            report_profile = get_report_profile(db_handle, plugin_manager, report_data)
-            validate_options(report_profile, report_options, allow_file=allow_file)
-            module = plugin_manager.load_plugin(report_data)
-            option_class = getattr(module, report_data.optionclass)
-            report_class = getattr(module, report_data.reportclass)
-
-            cl_report(
-                db_handle,
-                report_data.name,
-                report_data.category,
-                report_class,
-                option_class,
-                report_options,
-            )
-            return file_name, file_type
-    abort(404)
-
-
-def validate_options(report: Dict, report_options: Dict, allow_file: bool = False):
-    """Check validity of provided report options."""
-    if report["id"] == "familylines_graph":
-        if "gidlist" not in report_options or not report_options["gidlist"]:
-            abort(422)
-    for option in report_options:
-        if option not in report["options_dict"]:
-            abort(422)
-        if isinstance(report["options_help"][option][2], type([])):
-            option_list = []
-            for item in report["options_help"][option][2]:
-                # Some option specs include a comment part after a tab, e.g. to give the name of a family
-                # associated with a family ID. It's the part before the tab that's a valid value.
-                # Some tab-separated specs also have a colon before the tab.
-                option_list.append(item.split("\t")[0].rstrip(":"))
-            if report_options[option] not in option_list:
-                abort(422)
-            continue
-        if not isinstance(report_options[option], str):
-            abort(422)
-        if "A number" in report["options_help"][option][2]:
-            try:
-                float(report_options[option])
-            except ValueError:
-                abort(422)
-        if "Size in cm" in report["options_help"][option][2]:
-            try:
-                float(report_options[option])
-            except ValueError:
-                abort(422)
 
 
 class ReportsResource(ProtectedResource, GrampsJSONEncoder):
@@ -186,7 +61,7 @@ class ReportResource(ProtectedResource, GrampsJSONEncoder):
     def get(self, args: Dict, report_id: str) -> Response:
         """Get specific report attributes."""
         reports = get_reports(get_db_handle(), report_id=report_id)
-        if reports == []:
+        if not reports:
             abort(404)
         return self.response(200, reports[0])
 
@@ -197,6 +72,9 @@ class ReportFileResource(ProtectedResource, GrampsJSONEncoder):
     @use_args(
         {
             "options": fields.Str(validate=validate.Length(min=1)),
+            "locale": fields.Str(
+                load_default=None, validate=validate.Length(min=1, max=5)
+            ),
             "jwt": fields.String(required=False),
         },
         location="query",
@@ -212,14 +90,78 @@ class ReportFileResource(ProtectedResource, GrampsJSONEncoder):
         if "of" in report_options:
             abort(422)
 
-        file_name, file_type = run_report(get_db_handle(), report_id, report_options)
-        try:
-            buffer = get_buffer_for_file(file_name, not_found=True)
-        except FileNotFoundError:
-            if file_type == ".dot":
-                file_type = ".gv"
-                file_name = file_name + file_type
-                buffer = get_buffer_for_file(file_name)
-            else:
-                abort(500)
+        file_name, file_type = run_report(
+            db_handle=get_db_handle(),
+            report_id=report_id,
+            report_options=report_options,
+            language=args["locale"],
+        )
+        report_path = current_app.config.get("REPORT_DIR")
+        file_path = os.path.join(report_path, file_name)
+        buffer = get_buffer_for_file(file_path, not_found=True)
         return send_file(buffer, mimetype=MIME_TYPES[file_type])
+
+    @use_args(
+        {
+            "options": fields.Str(validate=validate.Length(min=1)),
+            "locale": fields.Str(
+                load_default=None, validate=validate.Length(min=1, max=5)
+            ),
+            "jwt": fields.String(required=False),
+        },
+        location="query",
+    )
+    def post(self, args: Dict, report_id: str) -> Response:
+        """Create the report."""
+        report_options = {}
+        if "options" in args:
+            try:
+                report_options = json.loads(args["options"])
+            except json.JSONDecodeError:
+                abort(400)
+        if "of" in report_options:
+            abort(422)
+        tree = get_tree_from_jwt()
+        task = run_task(
+            generate_report,
+            tree=tree,
+            report_id=report_id.lower(),
+            options=report_options,
+            view_private=has_permissions({PERM_VIEW_PRIVATE}),
+            locale=args["locale"],
+        )
+        if isinstance(task, AsyncResult):
+            return make_task_response(task)
+        return jsonify(task), 201
+
+
+class ReportFileResultResource(ProtectedResource, GrampsJSONEncoder):
+    """Report file result resource."""
+
+    def get(self, report_id: str, filename: str) -> Response:
+        """Get the processed file."""
+        if not check_report_id_exists(report_id):
+            # do not allow a non-existing report ID to be supplied by the user
+            abort(404)
+        report_path = current_app.config.get("REPORT_DIR")
+
+        # assert the filename is legit
+        regex = re.compile(
+            r"([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})(\.[\w\.]*)"
+        )
+        match = regex.match(filename)
+        if not match:
+            abort(422)
+
+        file_type = match.group(2)
+        file_path = os.path.join(report_path, filename)
+        if not os.path.isfile(file_path):
+            abort(404)
+        date_lastmod = time.localtime(os.path.getmtime(file_path))
+        buffer = get_buffer_for_file(file_path, delete=True)
+        mime_type = "application/octet-stream"
+        if file_type != ".pl" and file_type in mimetypes.types_map:
+            mime_type = mimetypes.types_map[file_type]
+        date_str = time.strftime("%Y%m%d%H%M%S", date_lastmod)
+        download_name = f"gramps-web-{report_id}-{date_str}{file_type}"
+        return send_file(buffer, mimetype=mime_type, download_name=download_name)

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -5769,6 +5769,12 @@ paths:
 
           If no _off_ option for report output file format is provided then pdf will be used as a fallback.
           The _of_ option for output file is rejected by this endpoint as the report file is ephemeral.
+      - name: locale
+        in: query
+        required: false
+        type: string
+        default: "current locale"
+        description: "The language code of the locale to use for the report."
       responses:
         200:
           description: "OK: Successful operation."
@@ -5810,6 +5816,12 @@ paths:
 
           If no _off_ option for report output file format is provided then pdf will be used as a fallback.
           The _of_ option for output file is rejected by this endpoint as the report file is ephemeral.
+      - name: locale
+        in: query
+        required: false
+        type: string
+        default: "current locale"
+        description: "The language code of the locale to use for the report."
       responses:
         201:
           description: "OK: report file generated."

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -5782,6 +5782,100 @@ paths:
           description: "Not Found: Report id not found."
         422:
           description: "Unprocessable Entity: Invalid or bad parameter provided."
+    post:
+      tags:
+      - reports
+      summary: "Get a specific report."
+      operationId: postReportFile
+      security:
+        - Bearer: []
+      parameters:
+      - name: report_id
+        in: path
+        required: true
+        type: string
+        description: "The report identifier."
+      - name: options
+        in: query
+        required: false
+        type: string
+        description: >
+          The report options. Must be provided in JSON format.
+
+
+          There are a core set of options common to all reports, and then sometimes additional options
+          specific to a given report. A few reports do not have defaults for all options and require
+          some be specified in order to run properly.
+
+
+          If no _off_ option for report output file format is provided then pdf will be used as a fallback.
+          The _of_ option for output file is rejected by this endpoint as the report file is ephemeral.
+      responses:
+        201:
+          description: "OK: report file generated."
+          schema:
+            type: object
+            properties:
+              file_name:
+                description: "The file name of the generated report."
+                type: string
+                example: 8fa0232e-d06b-40a9-a5e1-ee26ee2f970f.pdf
+              file_type:
+                description: "The extension name of the generated report file."
+                type: string
+                example: .pdf
+              url:
+                description: "The URL of the exported file."
+                type: string
+                example: /reports/ancestor_report/file/processed/8fa0232e-d06b-40a9-a5e1-ee26ee2f970f.pdf
+        202:
+          description: "Accepted: report will be generated in the background."
+          schema:
+            type: object
+            properties:
+              task:
+                $ref: "#/definitions/TaskReference"
+        400:
+          description: "Bad Request: Malformed request could not be parsed."
+        401:
+          description: "Unauthorized: Missing authorization header."
+        404:
+          description: "Not Found: Report id not found."
+        422:
+          description: "Unprocessable Entity: Invalid or bad parameter provided."
+
+
+
+  /reports/{report_id}/file/processed/{filename}:
+    get:
+      tags:
+      - reports
+      summary: "Download the generated report file."
+      operationId: getProcessedReportFile
+      security:
+        - Bearer: []
+      parameters:
+      - name: report_id
+        in: path
+        required: true
+        type: string
+        description: "The report identifier."
+      - name: filename
+        in: path
+        required: true
+        type: string
+        description: "The file name of the generated file."
+      responses:
+        200:
+          description: "OK: Successful operation."
+          schema:
+            type: file
+        401:
+          description: "Unauthorized: Missing authorization header."
+        404:
+          description: "Not Found: Exporter not found."
+        422:
+          description: "Unprocessable Entity: Invalid or bad parameter provided."
 
 
 ##############################################################################
@@ -9557,6 +9651,7 @@ definitions:
         description: "The version number of the report."
         type: string
         example: "1.0"
+
 
 ##############################################################################
 # Model - ReportHelpOption


### PR DESCRIPTION
This introduces task queue support for reports, similar to exporters implemented in #350. As in that case, a new POST endpoint is introduced in alongside the existing GET endpoint, and a new GET endpoint `/reports/{report_id}/file/processed/{filename}` is added to download the generated file.

In addition, this introduces localization support for text reports via a new `locale` query parameter.