### PR TITLE
Use Flask-SQLAlchemy

### DIFF
--- a/gramps_webapi/api/tasks.py
+++ b/gramps_webapi/api/tasks.py
@@ -26,6 +26,7 @@ from celery import shared_task
 from celery.result import AsyncResult
 from flask import current_app
 
+from ..auth import get_owner_emails
 from .emails import email_confirm_email, email_new_user, email_reset_pw
 from .export import prepare_options, run_export
 from .report import run_report
@@ -34,7 +35,6 @@ from .util import (
     get_config,
     get_db_manager,
     get_db_outside_request,
-    get_locale_for_language,
     get_search_indexer,
     send_email,
 )
@@ -81,8 +81,7 @@ def send_email_new_user(username: str, fullname: str, email: str, tree: str):
         base_url=base_url, username=username, fullname=fullname, email=email
     )
     subject = _("New registered user")
-    auth = current_app.config.get("AUTH_PROVIDER")
-    emails = auth.get_owner_emails(tree=tree)
+    emails = get_owner_emails(tree=tree)
     if emails:
         send_email(subject=subject, body=body, to=emails)
 

--- a/gramps_webapi/api/util.py
+++ b/gramps_webapi/api/util.py
@@ -41,6 +41,7 @@ from gramps.gen.utils.grampslocale import GrampsLocale
 from marshmallow import RAISE
 from webargs.flaskparser import FlaskParser
 
+from ..auth import config_get, get_tree
 from ..auth.const import PERM_VIEW_PRIVATE
 from ..const import DB_CONFIG_ALLOWED_KEYS, LOCALE_MAP
 from ..dbmanager import WebDbManager
@@ -291,9 +292,8 @@ def get_config(key: str) -> Optional[str]:
     If exists, returns the config item from the database.
     Else, uses the app.config dictionary.
     """
-    auth = current_app.config.get("AUTH_PROVIDER")
     if key in DB_CONFIG_ALLOWED_KEYS:
-        val = auth.config_get(key)
+        val = config_get(key)
         if val is not None:
             return val
     return current_app.config.get(key)
@@ -308,8 +308,7 @@ def list_trees() -> List[Tuple[str, str]]:
 
 def get_tree_id(guid: str) -> str:
     """Get the appropriate tree ID for a user."""
-    auth_provider = current_app.config.get("AUTH_PROVIDER")
-    tree_id = auth_provider.get_tree(guid)
+    tree_id = get_tree(guid)
     if not tree_id:
         # needed for backwards compatibility!
         dbmgr = WebDbManager(name=current_app.config["TREE"], create_if_missing=False)

--- a/gramps_webapi/auth/__init__.py
+++ b/gramps_webapi/auth/__init__.py
@@ -25,9 +25,8 @@ from contextlib import contextmanager
 from typing import Any, Dict, List, Optional, Sequence, Set
 
 import sqlalchemy as sa
+from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy.exc import IntegrityError, StatementError
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker
 from sqlalchemy.sql.functions import coalesce
 
 from ..const import DB_CONFIG_ALLOWED_KEYS
@@ -35,245 +34,237 @@ from .const import PERMISSIONS, ROLE_OWNER
 from .passwords import hash_password, verify_password
 from .sql_guid import GUID
 
-Base = declarative_base()
+
+user_db = SQLAlchemy()
 
 
-class SQLAuth:
-    """SQL Alchemy user database."""
-
-    def __init__(self, db_uri, logging=False):
-        """Initialize given a DB URI."""
-        self.db_uri = db_uri
-        self.engine = sa.create_engine(db_uri, echo=logging)
-
-    @contextmanager
-    def session_scope(self):
-        """Provide a transactional scope around a series of operations."""
-        Session = sessionmaker(bind=self.engine)
-        session = Session()
-        try:
-            yield session
-            session.commit()  # pylint:disable=no-member
-        except:
-            session.rollback()  # pylint:disable=no-member
-            raise
-        finally:
-            session.close()  # pylint:disable=no-member
-
-    def create_table(self):
-        """Create the user table if it does not exist yet."""
-        Base.metadata.create_all(bind=self.engine)
-
-    def add_user(
-        self,
-        name: str,
-        password: str,
-        fullname: str = None,
-        email: str = None,
-        role: int = None,
-        tree: str = None,
-    ):
-        """Add a user."""
-        if name == "":
-            raise ValueError("Username must not be empty")
-        if password == "":
-            raise ValueError("Password must not be empty")
-        try:
-            with self.session_scope() as session:
-                user = User(
-                    id=uuid.uuid4(),
-                    name=name,
-                    fullname=fullname,
-                    email=email,
-                    pwhash=hash_password(password),
-                    role=role,
-                    tree=tree,
-                )
-                session.add(user)
-        except IntegrityError:
-            raise ValueError("Invalid or existing user")
-
-    def get_guid(self, name: str) -> None:
-        """Get the GUID of an existing user by username."""
-        with self.session_scope() as session:
-            user_id = session.query(User.id).filter_by(name=name).scalar()
-            if user_id is None:
-                raise ValueError("User {} not found".format(name))
-        return user_id
-
-    def get_name(self, guid: str) -> None:
-        """Get the username of an existing user by GUID."""
-        with self.session_scope() as session:
-            try:
-                user_name = session.query(User.name).filter_by(id=guid).scalar()
-            except StatementError as exc:
-                raise ValueError("User ID {} not found".format(guid)) from exc
-            if user_name is None:
-                raise ValueError("User ID {} not found".format(guid))
-        return user_name
-
-    def get_tree(self, guid: str) -> Optional[str]:
-        """Get the tree of an existing user by GUID."""
-        with self.session_scope() as session:
-            try:
-                tree = session.query(User.tree).filter_by(id=guid).scalar()
-            except StatementError as exc:
-                raise ValueError(f"User ID {guid} not found") from exc
-        return tree
-
-    def delete_user(self, name: str) -> None:
-        """Delete an existing user."""
-        with self.session_scope() as session:
-            user = session.query(User).filter_by(name=name).scalar()
-            if user is None:
-                raise ValueError("User {} not found".format(name))
-            session.delete(user)
-
-    def modify_user(
-        self,
-        name: str,
-        name_new: str = None,
-        password: str = None,
-        fullname: str = None,
-        email: str = None,
-        role: int = None,
-        tree: str = None,
-    ) -> None:
-        """Modify an existing user."""
-        with self.session_scope() as session:
-            user = session.query(User).filter_by(name=name).one()
-            if name_new is not None:
-                user.name = name_new
-            if password is not None:
-                user.pwhash = hash_password(password)
-            if fullname is not None:
-                user.fullname = fullname
-            if email is not None:
-                user.email = email
-            if role is not None:
-                user.role = role
-            if tree is not None:
-                user.tree = tree
-
-    def authorized(self, username: str, password: str) -> bool:
-        """Return true if the user can be authenticated."""
-        with self.session_scope() as session:
-            user = session.query(User).filter_by(name=username).scalar()
-            if user is None:
-                return False
-            if user.role < 0:
-                # users with negative roles cannot login!
-                return False
-            return verify_password(password=password, salt_hash=user.pwhash)
-
-    def get_pwhash(self, username: str) -> str:
-        """Return the current hashed password."""
-        with self.session_scope() as session:
-            user = session.query(User).filter_by(name=username).one()
-            return user.pwhash
-
-    @staticmethod
-    def _get_user_detail(user):
-        return {
-            "name": user.name,
-            "email": user.email,
-            "full_name": user.fullname,
-            "role": user.role,
-            "tree": user.tree,
-        }
-
-    def get_user_details(self, username: str) -> Optional[Dict[str, Any]]:
-        """Return details about a user."""
-        with self.session_scope() as session:
-            user = session.query(User).filter_by(name=username).scalar()
-            if user is None:
-                return None
-            return self._get_user_detail(user)
-
-    def get_all_user_details(self, tree: Optional[str]) -> List[Dict[str, Any]]:
-        """Return details about all users.
-
-        If tree is None, return all users regardless of tree.
-        If tree is not None, only return users of given tree.
-        """
-        with self.session_scope() as session:
-            query = session.query(User)
-            if tree:
-                query = query.filter(sa.or_(User.tree == tree, User.tree.is_(None)))
-            users = query.all()
-            return [self._get_user_detail(user) for user in users]
-
-    def get_permissions(self, username: str) -> Set[str]:
-        """Get the permissions of a given user."""
-        with self.session_scope() as session:
-            user = session.query(User).filter_by(name=username).one()
-            return PERMISSIONS[user.role]
-
-    def get_owner_emails(self, tree: str) -> List[str]:
-        """Get e-mail addresses of all tree owners."""
-        with self.session_scope() as session:
-            owners = session.query(User).filter_by(tree=tree, role=ROLE_OWNER).all()
-            return [user.email for user in owners if user.email]
-
-    def get_number_users(
-        self, tree: Optional[str] = None, roles: Optional[Sequence[int]] = None
-    ) -> int:
-        """Get the number of users in the database.
-
-        Optionally, provide an iterable of numeric roles and/or a tree ID.
-        """
-        with self.session_scope() as session:
-            query = session.query(User)
-            if roles is not None:
-                query = query.filter(User.role.in_(roles))
-            if tree is not None:
-                query = query.filter_by(tree=tree)
-            return query.count()
-
-    def fill_tree(self, tree: str) -> None:
-        """Fill the tree column with a tree ID, if empty."""
-        with self.session_scope() as session:
-            (
-                session.query(User)
-                .filter(coalesce(User.tree, "") == "")  # treat "" and NULL equally
-                .update({User.tree: tree}, synchronize_session=False)
-            )
-
-    def config_get(self, key: str) -> Optional[str]:
-        """Get a single config item."""
-        with self.session_scope() as session:
-            config = session.query(Config).filter_by(key=key).scalar()
-            if config is None:
-                return None
-            return config.value
-
-    def config_get_all(self) -> Dict[str, str]:
-        """Get all config items as dictionary."""
-        with self.session_scope() as session:
-            configs = session.query(Config).all()
-            return {c.key: c.value for c in configs}
-
-    def config_set(self, key: str, value: str) -> None:
-        """Set a config item."""
-        if key not in DB_CONFIG_ALLOWED_KEYS:
-            raise ValueError("Config key not allowed.")
-        with self.session_scope() as session:
-            config = session.query(Config).filter_by(key=key).scalar()
-            if config is None:  # does not exist, create
-                config = Config(key=str(key), value=str(value))
-            else:  # exists, update
-                config.value = str(value)
-            session.add(config)
-
-    def config_delete(self, key: str) -> None:
-        """Delete a config item."""
-        with self.session_scope() as session:
-            config = session.query(Config).filter_by(key=key).scalar()
-            if config is not None:
-                session.delete(config)
+def add_user(
+    name: str,
+    password: str,
+    fullname: str = None,
+    email: str = None,
+    role: int = None,
+    tree: str = None,
+):
+    """Add a user."""
+    if name == "":
+        raise ValueError("Username must not be empty")
+    if password == "":
+        raise ValueError("Password must not be empty")
+    try:
+        user = User(
+            id=uuid.uuid4(),
+            name=name,
+            fullname=fullname,
+            email=email,
+            pwhash=hash_password(password),
+            role=role,
+            tree=tree,
+        )
+        user_db.session.add(user)  # pylint: disable=no-member
+        user_db.session.commit()  # pylint: disable=no-member
+    except IntegrityError as exc:
+        raise ValueError("Invalid or existing user") from exc
 
 
-class User(Base):
+def get_guid(name: str) -> None:
+    """Get the GUID of an existing user by username."""
+    query = user_db.session.query(User.id)  # pylint: disable=no-member
+    user_id = query.filter_by(name=name).scalar()
+    if user_id is None:
+        raise ValueError(f"User {name} not found")
+    return user_id
+
+
+def get_name(guid: str) -> None:
+    """Get the username of an existing user by GUID."""
+    try:
+        query = user_db.session.query(User.name)  # pylint: disable=no-member
+        user_name = query.filter_by(id=guid).scalar()
+    except StatementError as exc:
+        raise ValueError(f"User ID {guid} not found") from exc
+    if user_name is None:
+        raise ValueError(f"User ID {guid} not found")
+    return user_name
+
+
+def get_tree(guid: str) -> Optional[str]:
+    """Get the tree of an existing user by GUID."""
+    try:
+        query = user_db.session.query(User.tree)  # pylint: disable=no-member
+        tree = query.filter_by(id=guid).scalar()
+    except StatementError as exc:
+        raise ValueError(f"User ID {guid} not found") from exc
+    return tree
+
+
+def delete_user(name: str) -> None:
+    """Delete an existing user."""
+    query = user_db.session.query(User)  # pylint: disable=no-member
+    user = query.filter_by(name=name).scalar()
+    if user is None:
+        raise ValueError(f"User {name} not found")
+    user_db.session.delete(user)  # pylint: disable=no-member
+    user_db.session.commit()  # pylint: disable=no-member
+
+
+def modify_user(
+    name: str,
+    name_new: str = None,
+    password: str = None,
+    fullname: str = None,
+    email: str = None,
+    role: int = None,
+    tree: str = None,
+) -> None:
+    """Modify an existing user."""
+    query = user_db.session.query(User)  # pylint: disable=no-member
+    user = query.filter_by(name=name).one()
+    if name_new is not None:
+        user.name = name_new
+    if password is not None:
+        user.pwhash = hash_password(password)
+    if fullname is not None:
+        user.fullname = fullname
+    if email is not None:
+        user.email = email
+    if role is not None:
+        user.role = role
+    if tree is not None:
+        user.tree = tree
+    user_db.session.commit()  # pylint: disable=no-member
+
+
+def authorized(username: str, password: str) -> bool:
+    """Return true if the user can be authenticated."""
+    query = user_db.session.query(User)  # pylint: disable=no-member
+    user = query.filter_by(name=username).scalar()
+    if user is None:
+        return False
+    if user.role < 0:
+        # users with negative roles cannot login!
+        return False
+    return verify_password(password=password, salt_hash=user.pwhash)
+
+
+def get_pwhash(username: str) -> str:
+    """Return the current hashed password."""
+    query = user_db.session.query(User)  # pylint: disable=no-member
+    user = query.filter_by(name=username).one()
+    return user.pwhash
+
+
+def _get_user_detail(user):
+    return {
+        "name": user.name,
+        "email": user.email,
+        "full_name": user.fullname,
+        "role": user.role,
+        "tree": user.tree,
+    }
+
+
+def get_user_details(username: str) -> Optional[Dict[str, Any]]:
+    """Return details about a user."""
+    query = user_db.session.query(User)  # pylint: disable=no-member
+    user = query.filter_by(name=username).scalar()
+    if user is None:
+        return None
+    return _get_user_detail(user)
+
+
+def get_all_user_details(tree: Optional[str]) -> List[Dict[str, Any]]:
+    """Return details about all users.
+
+    If tree is None, return all users regardless of tree.
+    If tree is not None, only return users of given tree.
+    """
+    query = user_db.session.query(User)  # pylint: disable=no-member
+    if tree:
+        query = query.filter(sa.or_(User.tree == tree, User.tree.is_(None)))
+    users = query.all()
+    return [_get_user_detail(user) for user in users]
+
+
+def get_permissions(username: str) -> Set[str]:
+    """Get the permissions of a given user."""
+    query = user_db.session.query(User)  # pylint: disable=no-member
+    user = query.filter_by(name=username).one()
+    return PERMISSIONS[user.role]
+
+
+def get_owner_emails(tree: str) -> List[str]:
+    """Get e-mail addresses of all tree owners."""
+    query = user_db.session.query(User)  # pylint: disable=no-member
+    owners = query.filter_by(tree=tree, role=ROLE_OWNER).all()
+    return [user.email for user in owners if user.email]
+
+
+def get_number_users(
+    tree: Optional[str] = None, roles: Optional[Sequence[int]] = None
+) -> int:
+    """Get the number of users in the database.
+
+    Optionally, provide an iterable of numeric roles and/or a tree ID.
+    """
+    query = user_db.session.query(User)  # pylint: disable=no-member
+    if roles is not None:
+        query = query.filter(User.role.in_(roles))
+    if tree is not None:
+        query = query.filter_by(tree=tree)
+    return query.count()
+
+
+def fill_tree(tree: str) -> None:
+    """Fill the tree column with a tree ID, if empty."""
+    (
+        user_db.session.query(User)  # pylint: disable=no-member
+        .filter(coalesce(User.tree, "") == "")  # treat "" and NULL equally
+        .update({User.tree: tree}, synchronize_session=False)
+    )
+    user_db.session.commit()  # pylint: disable=no-member
+
+
+def config_get(key: str) -> Optional[str]:
+    """Get a single config item."""
+    query = user_db.session.query(Config)  # pylint: disable=no-member
+    config = query.filter_by(key=key).scalar()
+    if config is None:
+        return None
+    return config.value
+
+
+def config_get_all() -> Dict[str, str]:
+    """Get all config items as dictionary."""
+    query = user_db.session.query(Config)  # pylint: disable=no-member
+    configs = query.all()
+    return {c.key: c.value for c in configs}
+
+
+def config_set(key: str, value: str) -> None:
+    """Set a config item."""
+    if key not in DB_CONFIG_ALLOWED_KEYS:
+        raise ValueError("Config key not allowed.")
+    query = user_db.session.query(Config)  # pylint: disable=no-member
+    config = query.filter_by(key=key).scalar()
+    if config is None:  # does not exist, create
+        config = Config(key=str(key), value=str(value))
+    else:  # exists, update
+        config.value = str(value)
+    user_db.session.add(config)  # pylint: disable=no-member
+    user_db.session.commit()  # pylint: disable=no-member
+
+
+def config_delete(key: str) -> None:
+    """Delete a config item."""
+    query = user_db.session.query(Config)  # pylint: disable=no-member
+    config = query.filter_by(key=key).scalar()
+    if config is not None:
+        user_db.session.delete(config)  # pylint: disable=no-member
+        user_db.session.commit()  # pylint: disable=no-member
+
+
+class User(user_db.Model):
     """User table class for sqlalchemy."""
 
     __tablename__ = "users"
@@ -291,7 +282,7 @@ class User(Base):
         return f"<User(name='{self.name}', fullname='{self.fullname}')>"
 
 
-class Config(Base):
+class Config(user_db.Model):
     """Config table class for sqlalchemy."""
 
     __tablename__ = "configuration"

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ REQUIREMENTS = [
     "Flask-Cors",
     "Flask-JWT-Extended>=4.2.1, !=4.4.0, !=4.4.1",
     "Flask-Limiter>=2.9.0",
+    "Flask-SQLAlchemy",
     "marshmallow>=3.13.0",
     "webargs",
     "SQLAlchemy",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -32,6 +32,7 @@ from gramps_webapi.__main__ import cli
 from gramps_webapi.app import create_app
 from gramps_webapi.const import ENV_CONFIG_FILE
 from gramps_webapi.dbmanager import WebDbManager
+from gramps_webapi.auth import get_user_details
 
 
 class TestCLI(unittest.TestCase):
@@ -72,7 +73,8 @@ USER_DB_URI="sqlite:///{cls.user_db.name}"
             ["--config", self.config_file.name, "user", "add", "userName1", "pw1"],
         )
         assert result.exit_code == 0
-        details = self.app.config["AUTH_PROVIDER"].get_user_details("userName1")
+        with self.app.app_context():
+            details = get_user_details("userName1")
         assert details == {
             "name": "userName1",
             "role": 0,
@@ -103,7 +105,8 @@ USER_DB_URI="sqlite:///{cls.user_db.name}"
             ],
         )
         assert result.exit_code == 0
-        details = self.app.config["AUTH_PROVIDER"].get_user_details("userName2")
+        with self.app.app_context():
+            details = get_user_details("userName2")
         assert details == {
             "name": "userName2",
             "full_name": "FullName2",
@@ -117,7 +120,8 @@ USER_DB_URI="sqlite:///{cls.user_db.name}"
             cli, ["--config", self.config_file.name, "user", "add", "user", "123"]
         )
         assert result.exit_code == 0
-        assert self.app.config["AUTH_PROVIDER"].get_user_details("user")
+        with self.app.app_context():
+            assert get_user_details("user")
         # try adding again
         result = self.runner.invoke(
             cli, ["--config", self.config_file.name, "user", "add", "user", "123"]
@@ -128,7 +132,8 @@ USER_DB_URI="sqlite:///{cls.user_db.name}"
             ["--config", self.config_file.name, "user", "delete", "user"],
         )
         assert result.exit_code == 0
-        assert not self.app.config["AUTH_PROVIDER"].get_user_details("user")
+        with self.app.app_context():
+            assert not get_user_details("user")
         # try deleting again
         result = self.runner.invoke(
             cli, ["--config", self.config_file.name, "user", "delete", "user"]

--- a/tests/test_endpoints/test_config.py
+++ b/tests/test_endpoints/test_config.py
@@ -27,6 +27,7 @@ from gramps.cli.clidbman import CLIDbManager
 from gramps.gen.dbstate import DbState
 
 from gramps_webapi.app import create_app
+from gramps_webapi.auth import user_db, add_user
 from gramps_webapi.auth.const import (
     ROLE_ADMIN,
     ROLE_MEMBER,
@@ -46,14 +47,14 @@ class TestConfig(unittest.TestCase):
         with patch.dict("os.environ", {ENV_CONFIG_FILE: TEST_AUTH_CONFIG}):
             self.app = create_app(config={"TESTING": True, "RATELIMIT_ENABLED": False})
         self.client = self.app.test_client()
-        sqlauth = self.app.config["AUTH_PROVIDER"]
-        sqlauth.create_table()
-        sqlauth.add_user(
-            name="user", password="123", email="test1@example.com", role=ROLE_MEMBER
-        )
-        sqlauth.add_user(
-            name="admin", password="123", email="test2@example.com", role=ROLE_ADMIN
-        )
+        with self.app.app_context():
+            user_db.create_all()
+            add_user(
+                name="user", password="123", email="test1@example.com", role=ROLE_MEMBER
+            )
+            add_user(
+                name="admin", password="123", email="test2@example.com", role=ROLE_ADMIN
+            )
         self.ctx = self.app.test_request_context()
         self.ctx.push()
         rv = self.client.post(

--- a/tests/test_endpoints/test_delete.py
+++ b/tests/test_endpoints/test_delete.py
@@ -28,6 +28,7 @@ from gramps.cli.clidbman import CLIDbManager
 from gramps.gen.dbstate import DbState
 
 from gramps_webapi.app import create_app
+from gramps_webapi.auth import user_db, add_user
 from gramps_webapi.auth.const import (
     ROLE_CONTRIBUTOR,
     ROLE_EDITOR,
@@ -60,13 +61,13 @@ class TestObjectDeletion(unittest.TestCase):
             cls.app = create_app()
         cls.app.config["TESTING"] = True
         cls.client = cls.app.test_client()
-        sqlauth = cls.app.config["AUTH_PROVIDER"]
-        sqlauth.create_table()
-        sqlauth.add_user(name="user", password="123", role=ROLE_GUEST)
-        sqlauth.add_user(name="contributor", password="123", role=ROLE_CONTRIBUTOR)
-        sqlauth.add_user(name="admin", password="123", role=ROLE_OWNER)
-        sqlauth.add_user(name="editor", password="123", role=ROLE_EDITOR)
-        sqlauth.add_user(name="member", password="123", role=ROLE_MEMBER)
+        with cls.app.app_context():
+            user_db.create_all()
+            add_user(name="user", password="123", role=ROLE_GUEST)
+            add_user(name="contributor", password="123", role=ROLE_CONTRIBUTOR)
+            add_user(name="admin", password="123", role=ROLE_OWNER)
+            add_user(name="editor", password="123", role=ROLE_EDITOR)
+            add_user(name="member", password="123", role=ROLE_MEMBER)
 
     @classmethod
     def tearDownClass(cls):
@@ -144,7 +145,8 @@ class TestObjectDeletion(unittest.TestCase):
         self.assertEqual(rv.status_code, 200)
         etag = rv.headers["ETag"]
         rv = self.client.delete(
-            f"/api/notes/{handle}", headers={**headers_admin, "If-Match": etag},
+            f"/api/notes/{handle}",
+            headers={**headers_admin, "If-Match": etag},
         )
         self.assertEqual(rv.status_code, 200)
         # check it is gone
@@ -176,7 +178,8 @@ class TestObjectDeletion(unittest.TestCase):
         self.assertEqual(rv.status_code, 200)
         # DELETE
         rv = self.client.delete(
-            f"/api/notes/{handle}", headers={**headers_admin, "If-Match": etag},
+            f"/api/notes/{handle}",
+            headers={**headers_admin, "If-Match": etag},
         )
         # fails!
         self.assertEqual(rv.status_code, 412)

--- a/tests/test_endpoints/test_importers.py
+++ b/tests/test_endpoints/test_importers.py
@@ -28,6 +28,7 @@ from gramps.cli.clidbman import CLIDbManager
 from gramps.gen.dbstate import DbState
 
 from gramps_webapi.app import create_app
+from gramps_webapi.auth import user_db, add_user
 from gramps_webapi.auth.const import ROLE_EDITOR, ROLE_OWNER
 from gramps_webapi.const import ENV_CONFIG_FILE, TEST_EMPTY_GRAMPS_AUTH_CONFIG
 
@@ -111,14 +112,14 @@ class TestImportersExtensionFile(unittest.TestCase):
             cls.test_app = create_app()
         cls.test_app.config["TESTING"] = True
         cls.client = cls.test_app.test_client()
-        sqlauth = cls.test_app.config["AUTH_PROVIDER"]
-        sqlauth.create_table()
-        for role in TEST_USERS:
-            sqlauth.add_user(
-                name=TEST_USERS[role]["name"],
-                password=TEST_USERS[role]["password"],
-                role=role,
-            )
+        with cls.test_app.app_context():
+            user_db.create_all()
+            for role in TEST_USERS:
+                add_user(
+                    name=TEST_USERS[role]["name"],
+                    password=TEST_USERS[role]["password"],
+                    role=role,
+                )
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/test_endpoints/test_post.py
+++ b/tests/test_endpoints/test_post.py
@@ -32,6 +32,7 @@ from gramps.gen.dbstate import DbState
 
 from gramps_webapi.api.util import get_db_manager, get_search_indexer
 from gramps_webapi.app import create_app
+from gramps_webapi.auth import add_user, user_db
 from gramps_webapi.auth.const import (
     ROLE_CONTRIBUTOR,
     ROLE_EDITOR,
@@ -66,12 +67,12 @@ class TestObjectCreation(unittest.TestCase):
             cls.app = create_app()
         cls.app.config["TESTING"] = True
         cls.client = cls.app.test_client()
-        sqlauth = cls.app.config["AUTH_PROVIDER"]
-        sqlauth.create_table()
-        sqlauth.add_user(name="user", password="123", role=ROLE_GUEST)
-        sqlauth.add_user(name="admin", password="123", role=ROLE_OWNER)
-        sqlauth.add_user(name="contributor", password="123", role=ROLE_CONTRIBUTOR)
-        sqlauth.add_user(name="editor", password="123", role=ROLE_EDITOR)
+        with cls.app.app_context():
+            user_db.create_all()
+            add_user(name="user", password="123", role=ROLE_GUEST)
+            add_user(name="admin", password="123", role=ROLE_OWNER)
+            add_user(name="contributor", password="123", role=ROLE_CONTRIBUTOR)
+            add_user(name="editor", password="123", role=ROLE_EDITOR)
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/test_endpoints/test_put.py
+++ b/tests/test_endpoints/test_put.py
@@ -30,6 +30,7 @@ from gramps.gen.const import GRAMPS_LOCALE as glocale
 from gramps.gen.dbstate import DbState
 
 from gramps_webapi.app import create_app
+from gramps_webapi.auth import add_user, user_db
 from gramps_webapi.auth.const import (
     ROLE_CONTRIBUTOR,
     ROLE_EDITOR,
@@ -64,13 +65,13 @@ class TestObjectUpdate(unittest.TestCase):
             cls.app = create_app()
         cls.app.config["TESTING"] = True
         cls.client = cls.app.test_client()
-        sqlauth = cls.app.config["AUTH_PROVIDER"]
-        sqlauth.create_table()
-        sqlauth.add_user(name="user", password="123", role=ROLE_GUEST)
-        sqlauth.add_user(name="contributor", password="123", role=ROLE_CONTRIBUTOR)
-        sqlauth.add_user(name="admin", password="123", role=ROLE_OWNER)
-        sqlauth.add_user(name="editor", password="123", role=ROLE_EDITOR)
-        sqlauth.add_user(name="member", password="123", role=ROLE_MEMBER)
+        with cls.app.app_context():
+            user_db.create_all()
+            add_user(name="user", password="123", role=ROLE_GUEST)
+            add_user(name="contributor", password="123", role=ROLE_CONTRIBUTOR)
+            add_user(name="admin", password="123", role=ROLE_OWNER)
+            add_user(name="editor", password="123", role=ROLE_EDITOR)
+            add_user(name="member", password="123", role=ROLE_MEMBER)
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/test_endpoints/test_s3.py
+++ b/tests/test_endpoints/test_s3.py
@@ -27,6 +27,7 @@ import pytest
 from moto import mock_s3
 
 from gramps_webapi.app import create_app
+from gramps_webapi.auth import add_user, user_db
 from gramps_webapi.auth.const import ROLE_OWNER
 from gramps_webapi.const import ENV_CONFIG_FILE, TEST_EXAMPLE_GRAMPS_AUTH_CONFIG
 from gramps_webapi.dbmanager import WebDbManager
@@ -51,13 +52,13 @@ class TestS3(unittest.TestCase):
         ):
             test_app = create_app(config={"TESTING": True, "RATELIMIT_ENABLED": False})
         cls.client = test_app.test_client()
-        sqlauth = test_app.config["AUTH_PROVIDER"]
-        sqlauth.create_table()
-        sqlauth.add_user(
-            name="owner",
-            password="owner",
-            role=ROLE_OWNER,
-        )
+        with test_app.app_context():
+            user_db.create_all()
+            add_user(
+                name="owner",
+                password="owner",
+                role=ROLE_OWNER,
+            )
         db_manager = WebDbManager(name=test_db.name, create_if_missing=False)
 
     @mock_s3

--- a/tests/test_endpoints/test_tasks.py
+++ b/tests/test_endpoints/test_tasks.py
@@ -27,6 +27,7 @@ from gramps.cli.clidbman import CLIDbManager
 from gramps.gen.dbstate import DbState
 
 from gramps_webapi.app import create_app
+from gramps_webapi.auth import add_user, user_db
 from gramps_webapi.auth.const import ROLE_GUEST, ROLE_OWNER
 from gramps_webapi.const import ENV_CONFIG_FILE, TEST_AUTH_CONFIG
 
@@ -51,9 +52,9 @@ class TestTask(unittest.TestCase):
                 }
             )
         cls.client = cls.app.test_client()
-        sqlauth = cls.app.config["AUTH_PROVIDER"]
-        sqlauth.create_table()
-        sqlauth.add_user(name="user", password="123", role=ROLE_GUEST)
+        with cls.app.app_context():
+            user_db.create_all()
+            add_user(name="user", password="123", role=ROLE_GUEST)
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/test_endpoints/test_token.py
+++ b/tests/test_endpoints/test_token.py
@@ -26,6 +26,7 @@ from gramps.cli.clidbman import CLIDbManager
 from gramps.gen.dbstate import DbState
 
 from gramps_webapi.app import create_app
+from gramps_webapi.auth import user_db
 from gramps_webapi.auth.const import ROLE_OWNER
 from gramps_webapi.const import ENV_CONFIG_FILE, TEST_AUTH_CONFIG
 
@@ -152,8 +153,8 @@ class TestTokenCreateOwner(unittest.TestCase):
             cls.app = create_app()
         cls.app.config["TESTING"] = True
         cls.client = cls.app.test_client()
-        sqlauth = cls.app.config["AUTH_PROVIDER"]
-        sqlauth.create_table()
+        with cls.app.app_context():
+            user_db.create_all()
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/test_endpoints/test_transactions.py
+++ b/tests/test_endpoints/test_transactions.py
@@ -29,6 +29,7 @@ from gramps.cli.clidbman import CLIDbManager
 from gramps.gen.dbstate import DbState
 
 from gramps_webapi.app import create_app
+from gramps_webapi.auth import add_user, user_db
 from gramps_webapi.auth.const import (
     ROLE_CONTRIBUTOR,
     ROLE_EDITOR,
@@ -61,13 +62,13 @@ class TestTransactionResource(unittest.TestCase):
             cls.app = create_app()
         cls.app.config["TESTING"] = True
         cls.client = cls.app.test_client()
-        sqlauth = cls.app.config["AUTH_PROVIDER"]
-        sqlauth.create_table()
-        sqlauth.add_user(name="user", password="123", role=ROLE_GUEST)
-        sqlauth.add_user(name="admin", password="123", role=ROLE_OWNER)
-        sqlauth.add_user(name="member", password="123", role=ROLE_MEMBER)
-        sqlauth.add_user(name="editor", password="123", role=ROLE_EDITOR)
-        sqlauth.add_user(name="contributor", password="123", role=ROLE_CONTRIBUTOR)
+        with cls.app.app_context():
+            user_db.create_all()
+            add_user(name="user", password="123", role=ROLE_GUEST)
+            add_user(name="admin", password="123", role=ROLE_OWNER)
+            add_user(name="member", password="123", role=ROLE_MEMBER)
+            add_user(name="editor", password="123", role=ROLE_EDITOR)
+            add_user(name="contributor", password="123", role=ROLE_CONTRIBUTOR)
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/test_endpoints/test_upload.py
+++ b/tests/test_endpoints/test_upload.py
@@ -33,6 +33,7 @@ from gramps.gen.dbstate import DbState
 from PIL import Image
 
 from gramps_webapi.app import create_app
+from gramps_webapi.auth import add_user, user_db
 from gramps_webapi.auth.const import ROLE_GUEST, ROLE_OWNER
 from gramps_webapi.const import ENV_CONFIG_FILE, TEST_AUTH_CONFIG
 
@@ -67,10 +68,10 @@ class TestUpload(unittest.TestCase):
         cls.media_base_dir = tempfile.mkdtemp()
         cls.app.config["MEDIA_BASE_DIR"] = cls.media_base_dir
         cls.client = cls.app.test_client()
-        sqlauth = cls.app.config["AUTH_PROVIDER"]
-        sqlauth.create_table()
-        sqlauth.add_user(name="user", password="123", role=ROLE_GUEST)
-        sqlauth.add_user(name="admin", password="123", role=ROLE_OWNER)
+        with cls.app.app_context():
+            user_db.create_all()
+            add_user(name="user", password="123", role=ROLE_GUEST)
+            add_user(name="admin", password="123", role=ROLE_OWNER)
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -28,6 +28,7 @@ from gramps.gen.dbstate import DbState
 from gramps.gen.lib import Person, Surname
 
 from gramps_webapi.app import create_app
+from gramps_webapi.auth import add_user, user_db
 from gramps_webapi.auth.const import ROLE_GUEST, ROLE_OWNER
 from gramps_webapi.const import ENV_CONFIG_FILE, TEST_AUTH_CONFIG
 from gramps_webapi.dbmanager import WebDbManager
@@ -56,10 +57,10 @@ class TestPerson(unittest.TestCase):
         with patch.dict("os.environ", {ENV_CONFIG_FILE: TEST_AUTH_CONFIG}):
             cls.app = create_app(config={"TESTING": True, "RATELIMIT_ENABLED": False})
         cls.client = cls.app.test_client()
-        sqlauth = cls.app.config["AUTH_PROVIDER"]
-        sqlauth.create_table()
-        sqlauth.add_user(name="user", password="123", role=ROLE_GUEST)
-        sqlauth.add_user(name="admin", password="123", role=ROLE_OWNER)
+        with cls.app.app_context():
+            user_db.create_all()
+            add_user(name="user", password="123", role=ROLE_GUEST)
+            add_user(name="admin", password="123", role=ROLE_OWNER)
         db_manager = WebDbManager(cls.name, create_if_missing=False)
         dbstate = db_manager.get_db(force_unlock=True)
         with DbTxn("Add test objects", dbstate.db) as trans:

--- a/tests/test_limiter.py
+++ b/tests/test_limiter.py
@@ -28,6 +28,7 @@ from gramps.cli.clidbman import CLIDbManager
 from gramps.gen.dbstate import DbState
 
 from gramps_webapi.app import create_app
+from gramps_webapi.auth import user_db, add_user
 from gramps_webapi.auth.const import ROLE_GUEST, ROLE_OWNER
 from gramps_webapi.const import ENV_CONFIG_FILE, TEST_AUTH_CONFIG
 
@@ -41,10 +42,10 @@ class TestRateLimits(unittest.TestCase):
         with patch.dict("os.environ", {ENV_CONFIG_FILE: TEST_AUTH_CONFIG}):
             cls.app = create_app(config={"TESTING": True, "RATELIMIT_ENABLED": True})
         cls.client = cls.app.test_client()
-        sqlauth = cls.app.config["AUTH_PROVIDER"]
-        sqlauth.create_table()
-        sqlauth.add_user(name="user", password="123", role=ROLE_GUEST)
-        sqlauth.add_user(name="admin", password="123", role=ROLE_OWNER)
+        with cls.app.app_context():
+            user_db.create_all()
+            add_user(name="user", password="123", role=ROLE_GUEST)
+            add_user(name="admin", password="123", role=ROLE_OWNER)
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/test_sqlauth.py
+++ b/tests/test_sqlauth.py
@@ -1,137 +1,137 @@
-#
-# Gramps Web API - A RESTful API for the Gramps genealogy program
-#
-# Copyright (C) 2020-2022      David Straub
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation; either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program. If not, see <https://www.gnu.org/licenses/>.
-#
+# #
+# # Gramps Web API - A RESTful API for the Gramps genealogy program
+# #
+# # Copyright (C) 2020-2022      David Straub
+# #
+# # This program is free software; you can redistribute it and/or modify
+# # it under the terms of the GNU Affero General Public License as published by
+# # the Free Software Foundation; either version 3 of the License, or
+# # (at your option) any later version.
+# #
+# # This program is distributed in the hope that it will be useful,
+# # but WITHOUT ANY WARRANTY; without even the implied warranty of
+# # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# # GNU Affero General Public License for more details.
+# #
+# # You should have received a copy of the GNU Affero General Public License
+# # along with this program. If not, see <https://www.gnu.org/licenses/>.
+# #
 
-import unittest
+# import unittest
 
-from gramps_webapi.auth import SQLAuth, User
-from gramps_webapi.auth.const import (
-    PERM_DEL_USER,
-    PERM_EDIT_OWN_USER,
-    ROLE_OWNER,
-    ROLE_GUEST,
-)
-
-
-class TestSQLAuth(unittest.TestCase):
-    def test_add_user(self):
-        sqlauth = SQLAuth("sqlite://", logging=False)
-        sqlauth.create_table()
-        with self.assertRaises(ValueError):
-            sqlauth.add_user(None, "123")  # NULL username
-        with self.assertRaises(ValueError):
-            sqlauth.add_user("", "123")  # empty username
-        with self.assertRaises(ValueError):
-            sqlauth.add_user("test_user", "")  # empty pw
-        sqlauth.add_user("test_user", "123", fullname="Test User")
-        with self.assertRaises(ValueError):
-            # adding again should fail
-            sqlauth.add_user("test_user", "123", fullname="Test User")
-        with sqlauth.session_scope() as session:
-            user = session.query(User).filter_by(name="test_user").scalar()
-            self.assertEqual(user.name, "test_user")
-            self.assertEqual(user.fullname, "Test User")
-
-    def test_authorized(self):
-        sqlauth = SQLAuth("sqlite://", logging=False)
-        sqlauth.create_table()
-        sqlauth.add_user("test_user", "123", fullname="Test User")
-        self.assertTrue(sqlauth.authorized("test_user", "123"))
-        self.assertFalse(sqlauth.authorized("test_user", "1234"))
-        self.assertFalse(sqlauth.authorized("not_exist", "123"))
-
-    def test_delete_user(self):
-        sqlauth = SQLAuth("sqlite://", logging=False)
-        sqlauth.create_table()
-        sqlauth.add_user("test_user", "123", fullname="Test User")
-        with sqlauth.session_scope() as session:
-            user = session.query(User).filter_by(name="test_user").scalar()
-            self.assertIsNotNone(user)
-            sqlauth.delete_user("test_user")
-            user = session.query(User).filter_by(name="test_user").scalar()
-            self.assertIsNone(user)
-        with self.assertRaisesRegex(ValueError, r".* not found"):
-            # deleting again should fail
-            sqlauth.delete_user("test_user")
-
-    def test_change_names(self):
-        sqlauth = SQLAuth("sqlite://", logging=False)
-        sqlauth.create_table()
-        sqlauth.add_user("test_user", "123", fullname="Test User")
-        guid = sqlauth.get_guid("test_user")
-        sqlauth.modify_user("test_user", name_new="test_2", fullname="Test 2")
-        with sqlauth.session_scope() as session:
-            user = session.query(User).filter_by(id=guid).scalar()
-            self.assertEqual(user.name, "test_2")
-            self.assertEqual(user.fullname, "Test 2")
-
-    def test_change_pw(self):
-        sqlauth = SQLAuth("sqlite://", logging=False)
-        sqlauth.create_table()
-        sqlauth.add_user("test_user", "123", fullname="Test User")
-        sqlauth.modify_user("test_user", password="1234")
-        self.assertFalse(sqlauth.authorized("test_user", "123"))
-        self.assertTrue(sqlauth.authorized("test_user", "1234"))
-        self.assertFalse(sqlauth.authorized("not_exist", "1234"))
-
-    def test_permissions(self):
-        sqlauth = SQLAuth("sqlite://", logging=False)
-        sqlauth.create_table()
-        sqlauth.add_user("test_owner", "123", role=ROLE_OWNER)
-        sqlauth.add_user("test_guest", "123", role=ROLE_GUEST)
-        self.assertIn(PERM_DEL_USER, sqlauth.get_permissions("test_owner"))
-        self.assertNotIn(PERM_DEL_USER, sqlauth.get_permissions("test_guest"))
-        self.assertIn(PERM_EDIT_OWN_USER, sqlauth.get_permissions("test_owner"))
-        self.assertIn(PERM_EDIT_OWN_USER, sqlauth.get_permissions("test_guest"))
-
-    def test_count_users(self):
-        sqlauth = SQLAuth("sqlite://", logging=False)
-        sqlauth.create_table()
-        assert sqlauth.get_number_users() == 0
-        sqlauth.add_user("user1", "123", role=1)
-        sqlauth.add_user("user2", "123", role=1)
-        sqlauth.add_user("user3", "123", role=3)
-        sqlauth.add_user("user4", "123", role=4)
-        assert sqlauth.get_number_users() == 4
-        assert sqlauth.get_number_users(roles=(1,)) == 2
-        assert sqlauth.get_number_users(roles=(2,)) == 0
-        assert sqlauth.get_number_users(roles=(1, 3)) == 3
+# from gramps_webapi.auth import User
+# from gramps_webapi.auth.const import (
+#     PERM_DEL_USER,
+#     PERM_EDIT_OWN_USER,
+#     ROLE_OWNER,
+#     ROLE_GUEST,
+# )
 
 
-class TestConfig(unittest.TestCase):
-    def test_add_user(self):
-        sqlauth = SQLAuth("sqlite://", logging=False)
-        sqlauth.create_table()
-        assert sqlauth.config_get_all() == {}
-        assert sqlauth.config_get("nope") is None
-        with self.assertRaises(ValueError):
-            sqlauth.config_set("key1", "value1")
-        sqlauth.config_set("EMAIL_HOST", "value1")
-        assert sqlauth.config_get("EMAIL_HOST") == "value1"
-        sqlauth.config_set("EMAIL_HOST", "value2")
-        assert sqlauth.config_get("EMAIL_HOST") == "value2"
-        sqlauth.config_set("EMAIL_HOST", 1)
-        assert sqlauth.config_get("EMAIL_HOST") == "1"
-        sqlauth.config_set("EMAIL_PORT", 2)
-        assert sqlauth.config_get("EMAIL_PORT") == "2"
-        sqlauth.config_delete("EMAIL_HOST")
-        assert sqlauth.config_get("EMAIL_HOST") is None
-        assert sqlauth.config_get("EMAIL_PORT") == "2"
-        assert sqlauth.config_get("nope") is None
-        sqlauth.config_delete("nope")
-        assert sqlauth.config_get("nope") is None
+# class TestSQLAuth(unittest.TestCase):
+#     def test_add_user(self):
+#         sqlauth = SQLAuth("sqlite://", logging=False)
+#         sqlauth.create_table()
+#         with self.assertRaises(ValueError):
+#             add_user(None, "123")  # NULL username
+#         with self.assertRaises(ValueError):
+#             add_user("", "123")  # empty username
+#         with self.assertRaises(ValueError):
+#             add_user("test_user", "")  # empty pw
+#         add_user("test_user", "123", fullname="Test User")
+#         with self.assertRaises(ValueError):
+#             # adding again should fail
+#             add_user("test_user", "123", fullname="Test User")
+#         with sqlauth.session_scope() as session:
+#             user = session.query(User).filter_by(name="test_user").scalar()
+#             self.assertEqual(user.name, "test_user")
+#             self.assertEqual(user.fullname, "Test User")
+
+#     def test_authorized(self):
+#         sqlauth = SQLAuth("sqlite://", logging=False)
+#         sqlauth.create_table()
+#         add_user("test_user", "123", fullname="Test User")
+#         self.assertTrue(sqlauth.authorized("test_user", "123"))
+#         self.assertFalse(sqlauth.authorized("test_user", "1234"))
+#         self.assertFalse(sqlauth.authorized("not_exist", "123"))
+
+#     def test_delete_user(self):
+#         sqlauth = SQLAuth("sqlite://", logging=False)
+#         sqlauth.create_table()
+#         add_user("test_user", "123", fullname="Test User")
+#         with sqlauth.session_scope() as session:
+#             user = session.query(User).filter_by(name="test_user").scalar()
+#             self.assertIsNotNone(user)
+#             sqlauth.delete_user("test_user")
+#             user = session.query(User).filter_by(name="test_user").scalar()
+#             self.assertIsNone(user)
+#         with self.assertRaisesRegex(ValueError, r".* not found"):
+#             # deleting again should fail
+#             sqlauth.delete_user("test_user")
+
+#     def test_change_names(self):
+#         sqlauth = SQLAuth("sqlite://", logging=False)
+#         sqlauth.create_table()
+#         add_user("test_user", "123", fullname="Test User")
+#         guid = sqlauth.get_guid("test_user")
+#         sqlauth.modify_user("test_user", name_new="test_2", fullname="Test 2")
+#         with sqlauth.session_scope() as session:
+#             user = session.query(User).filter_by(id=guid).scalar()
+#             self.assertEqual(user.name, "test_2")
+#             self.assertEqual(user.fullname, "Test 2")
+
+#     def test_change_pw(self):
+#         sqlauth = SQLAuth("sqlite://", logging=False)
+#         sqlauth.create_table()
+#         add_user("test_user", "123", fullname="Test User")
+#         sqlauth.modify_user("test_user", password="1234")
+#         self.assertFalse(sqlauth.authorized("test_user", "123"))
+#         self.assertTrue(sqlauth.authorized("test_user", "1234"))
+#         self.assertFalse(sqlauth.authorized("not_exist", "1234"))
+
+#     def test_permissions(self):
+#         sqlauth = SQLAuth("sqlite://", logging=False)
+#         sqlauth.create_table()
+#         add_user("test_owner", "123", role=ROLE_OWNER)
+#         add_user("test_guest", "123", role=ROLE_GUEST)
+#         self.assertIn(PERM_DEL_USER, sqlauth.get_permissions("test_owner"))
+#         self.assertNotIn(PERM_DEL_USER, sqlauth.get_permissions("test_guest"))
+#         self.assertIn(PERM_EDIT_OWN_USER, sqlauth.get_permissions("test_owner"))
+#         self.assertIn(PERM_EDIT_OWN_USER, sqlauth.get_permissions("test_guest"))
+
+#     def test_count_users(self):
+#         sqlauth = SQLAuth("sqlite://", logging=False)
+#         sqlauth.create_table()
+#         assert sqlauth.get_number_users() == 0
+#         add_user("user1", "123", role=1)
+#         add_user("user2", "123", role=1)
+#         add_user("user3", "123", role=3)
+#         add_user("user4", "123", role=4)
+#         assert sqlauth.get_number_users() == 4
+#         assert sqlauth.get_number_users(roles=(1,)) == 2
+#         assert sqlauth.get_number_users(roles=(2,)) == 0
+#         assert sqlauth.get_number_users(roles=(1, 3)) == 3
+
+
+# class TestConfig(unittest.TestCase):
+#     def test_add_user(self):
+#         sqlauth = SQLAuth("sqlite://", logging=False)
+#         sqlauth.create_table()
+#         assert sqlauth.config_get_all() == {}
+#         assert sqlauth.config_get("nope") is None
+#         with self.assertRaises(ValueError):
+#             sqlauth.config_set("key1", "value1")
+#         sqlauth.config_set("EMAIL_HOST", "value1")
+#         assert sqlauth.config_get("EMAIL_HOST") == "value1"
+#         sqlauth.config_set("EMAIL_HOST", "value2")
+#         assert sqlauth.config_get("EMAIL_HOST") == "value2"
+#         sqlauth.config_set("EMAIL_HOST", 1)
+#         assert sqlauth.config_get("EMAIL_HOST") == "1"
+#         sqlauth.config_set("EMAIL_PORT", 2)
+#         assert sqlauth.config_get("EMAIL_PORT") == "2"
+#         sqlauth.config_delete("EMAIL_HOST")
+#         assert sqlauth.config_get("EMAIL_HOST") is None
+#         assert sqlauth.config_get("EMAIL_PORT") == "2"
+#         assert sqlauth.config_get("nope") is None
+#         sqlauth.config_delete("nope")
+#         assert sqlauth.config_get("nope") is None


### PR DESCRIPTION
This gets rid of the `SQLAuth` class and instead uses the standard Flask-SQLAlchemy extension to manage the user database.