### PR TITLE
Support STARTTLS

### DIFF
--- a/gramps_webapi/api/util.py
+++ b/gramps_webapi/api/util.py
@@ -244,6 +244,10 @@ def send_email(
             smtp = smtplib.SMTP_SSL(host=host, port=port, timeout=10)
         else:
             smtp = smtplib.SMTP(host=host, port=port, timeout=10)
+            smtp.ehlo()
+            if port != 25:
+                smtp.starttls()
+                smtp.ehlo()
         if user:
             smtp.login(user, password)
         smtp.send_message(msg)


### PR DESCRIPTION
This should fix #363: it is now assumed that, when `EMAIL_USE_TLS` is `False` and `EMAIL_PORT` is *not* 25, STARTTLS is desired.