### PR TITLE
Allow SharedPostgreSQL backend, also for new trees

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,10 @@ ENV GRAMPSWEB_EXPORT_DIR=/app/cache/export
 # install PostgreSQL addon
 RUN wget https://github.com/gramps-project/addons/archive/refs/heads/master.zip \
     && unzip -p master.zip addons-master/gramps$GRAMPS_VERSION/download/PostgreSQL.addon.tgz | \
-    tar -xvz -C /root/.gramps/gramps$GRAMPS_VERSION/plugins && rm master.zip
+    tar -xvz -C /root/.gramps/gramps$GRAMPS_VERSION/plugins \
+    && unzip -p master.zip addons-master/gramps$GRAMPS_VERSION/download/SharedPostgreSQL.addon.tgz | \
+    tar -xvz -C /root/.gramps/gramps$GRAMPS_VERSION/plugins \
+    && rm master.zip
 
 # install gunicorn
 RUN python3 -m pip install --no-cache-dir --extra-index-url https://www.piwheels.org/simple \

--- a/gramps_webapi/api/resources/trees.py
+++ b/gramps_webapi/api/resources/trees.py
@@ -78,9 +78,7 @@ class TreesResource(ProtectedResource):
         return [get_tree_details(tree_id) for tree_id in tree_ids]
 
     @use_args(
-        {
-            "name": fields.Str(required=True),
-        },
+        {"name": fields.Str(required=True)},
         location="json",
     )
     def post(self, args):
@@ -89,7 +87,13 @@ class TreesResource(ProtectedResource):
             abort(405)
         require_permissions([PERM_ADD_TREE])
         tree_id = str(uuid.uuid4())
-        dbmgr = WebDbManager(dirname=tree_id, name=args["name"], create_if_missing=True)
+        backend = current_app.config["NEW_DB_BACKEND"]
+        dbmgr = WebDbManager(
+            dirname=tree_id,
+            name=args["name"],
+            create_if_missing=True,
+            create_backend=backend,
+        )
         return {"name": args["name"], "tree_id": dbmgr.dirname}, 201
 
 

--- a/gramps_webapi/app.py
+++ b/gramps_webapi/app.py
@@ -28,6 +28,7 @@ from flask import Flask, abort, g, send_from_directory
 from flask_compress import Compress
 from flask_cors import CORS
 from flask_jwt_extended import JWTManager
+from gramps.gen.config import config as gramps_config
 
 from .api import api_blueprint
 from .api.cache import thumbnail_cache
@@ -117,6 +118,11 @@ def create_app(config: Optional[Dict[str, Any]] = None):
             "set to `False`. This is strongly discouraged as it exposes media "
             "files to users belonging to different trees!"
         )
+
+    if app.config["TREE"] == TREE_MULTI and app.config["NEW_DB_BACKEND"] != "sqlite":
+        # needed in case a new postgres tree is to be created
+        gramps_config.set("database.host", app.config["POSTGRES_HOST"])
+        gramps_config.set("database.port", app.config["POSTGRES_PORT"])
 
     # load JWT default settings
     app.config.from_object(DefaultConfigJWT)

--- a/gramps_webapi/auth/__init__.py
+++ b/gramps_webapi/auth/__init__.py
@@ -67,7 +67,7 @@ def add_user(
         raise ValueError("Invalid or existing user") from exc
 
 
-def get_guid(name: str) -> None:
+def get_guid(name: str) -> str:
     """Get the GUID of an existing user by username."""
     query = user_db.session.query(User.id)  # pylint: disable=no-member
     user_id = query.filter_by(name=name).scalar()
@@ -76,7 +76,7 @@ def get_guid(name: str) -> None:
     return user_id
 
 
-def get_name(guid: str) -> None:
+def get_name(guid: str) -> str:
     """Get the username of an existing user by GUID."""
     try:
         query = user_db.session.query(User.name)  # pylint: disable=no-member

--- a/gramps_webapi/config.py
+++ b/gramps_webapi/config.py
@@ -46,11 +46,14 @@ class DefaultConfig(object):
     }
     POSTGRES_USER = None
     POSTGRES_PASSWORD = None
+    POSTGRES_HOST = "localhost"
+    POSTGRES_PORT = "5432"
     CELERY_CONFIG: Dict[str, str] = {}
     MEDIA_BASE_DIR = ""
     MEDIA_PREFIX_TREE = False
     REPORT_DIR = str(Path.cwd() / "report_cache")
     EXPORT_DIR = str(Path.cwd() / "export_cache")
+    NEW_DB_BACKEND = "sqlite"
 
 
 class DefaultConfigJWT(object):


### PR DESCRIPTION
Fixes #367.

- Add plugin installation to docker container
- Add dbid to list of allowed backends
- Add `NEW_DB_BACKEND`, `POSTGRESQL_HOST`, `POSTGRESQL_PORT` config options