### PR TITLE
Allow specifying quota on tree creation

### DIFF
--- a/gramps_webapi/api/resources/trees.py
+++ b/gramps_webapi/api/resources/trees.py
@@ -85,7 +85,11 @@ class TreesResource(ProtectedResource):
         return [get_tree_details(tree_id) for tree_id in tree_ids]
 
     @use_args(
-        {"name": fields.Str(required=True)},
+        {
+            "name": fields.Str(required=True),
+            "quota_media": fields.Integer(required=False),
+            "quota_people": fields.Integer(required=False),
+        },
         location="json",
     )
     def post(self, args):
@@ -101,7 +105,13 @@ class TreesResource(ProtectedResource):
             create_if_missing=True,
             create_backend=backend,
         )
-        return {"name": args["name"], "tree_id": dbmgr.dirname}, 201
+        if args.get("quota_media") or args.get("quota_people"):
+            set_tree_quota(
+                tree=tree_id,
+                quota_media=args.get("quota_media"),
+                quota_people=args.get("quota_people"),
+            )
+        return get_tree_details(tree_id), 201
 
 
 class TreeResource(ProtectedResource):

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -6696,6 +6696,16 @@ paths:
         in: body
         required: true
         description: "The name of the tree."
+      - name: quota_media
+        in: body
+        type: integer
+        required: true
+        description: "The maxium size of media objects."
+      - name: quota_people
+        in: body
+        type: integer
+        required: true
+        description: "The maxium number of people."
       tags:
       - trees
       summary: "Create a new empty tree."
@@ -6706,14 +6716,7 @@ paths:
         201:
           description: "OK: resource created."
           schema:
-            type: object
-            properties:
-              name:
-                description: "The tree name."
-                type: string
-              tree_id:
-                description: "The tree ID."
-                type: string
+            $ref: "#/definitions/Tree"
         401:
           description: "Unauthorized: Missing authorization header."
         404:
@@ -6754,6 +6757,16 @@ paths:
           required: true
           type: string
           description: "The tree ID."
+        - name: quota_media
+          in: body
+          type: integer
+          required: true
+          description: "The maxium size of media objects."
+        - name: quota_people
+          in: body
+          type: integer
+          required: true
+          description: "The maxium number of people."
       tags:
       - trees
       summary: "Update details about a tree."

--- a/tests/test_endpoints/test_trees.py
+++ b/tests/test_endpoints/test_trees.py
@@ -127,11 +127,13 @@ class TestTrees(unittest.TestCase):
         rv = self.client.post(
             BASE_URL + "/trees/",
             headers={"Authorization": f"Bearer {token}"},
-            json={"name": "some name"},
+            json={"name": "some name", "quota_media": 1000000},
         )
         assert rv.status_code == 201
-        assert rv.json["tree_id"]
+        assert rv.json["id"]
         assert rv.json["name"] == "some name"
+        assert rv.json["quota_media"] == 1000000
+        assert rv.json["quota_people"] is None
 
     def test_rename_tree(self):
         rv = self.client.post(
@@ -148,7 +150,7 @@ class TestTrees(unittest.TestCase):
             json={"name": "my old name"},
         )
         assert rv.status_code == 201
-        tree_id = rv.json["tree_id"]
+        tree_id = rv.json["id"]
         # missing authorization
         rv = self.client.put(
             BASE_URL + f"/trees/{tree_id}",


### PR DESCRIPTION
This allows specifying `quota_media` and `quota_people` on creating a new tree.

It also changes the return value to match the `GET` endpoints.