### PR TITLE
Allow tree owner creation

### DIFF
--- a/gramps_webapi/api/resources/token.py
+++ b/gramps_webapi/api/resources/token.py
@@ -37,6 +37,7 @@ from ...auth import (
     get_permissions,
 )
 from ...auth.const import CLAIM_LIMITED_SCOPE, SCOPE_CREATE_ADMIN, SCOPE_CREATE_OWNER
+from ...const import TREE_MULTI
 from ..ratelimiter import limiter
 from ..util import get_tree_id, tree_exists, use_args
 from . import RefreshProtectedResource, Resource
@@ -139,6 +140,12 @@ class TokenCreateOwnerResource(Resource):
     def post(self, args):
         """Get a token."""
         tree = args.get("tree")
+        if (
+            tree
+            and current_app.config["TREE"] != TREE_MULTI
+            and tree != current_app.config["TREE"]
+        ):
+            abort(403)
         if tree and not tree_exists(tree):
             abort(404)
         if get_all_user_details(tree=tree):

--- a/gramps_webapi/api/resources/token.py
+++ b/gramps_webapi/api/resources/token.py
@@ -1,7 +1,7 @@
 #
 # Gramps Web API - A RESTful API for the Gramps genealogy program
 #
-# Copyright (C) 2020      David Straub
+# Copyright (C) 2020-2023      David Straub
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -30,15 +30,15 @@ from flask_jwt_extended import (
 from webargs import fields, validate
 
 from ...auth import (
-    get_all_user_details,
-    get_permissions,
-    get_guid,
     authorized,
+    get_all_user_details,
+    get_guid,
     get_name,
+    get_permissions,
 )
-from ...auth.const import CLAIM_LIMITED_SCOPE, SCOPE_CREATE_ADMIN
+from ...auth.const import CLAIM_LIMITED_SCOPE, SCOPE_CREATE_ADMIN, SCOPE_CREATE_OWNER
 from ..ratelimiter import limiter
-from ..util import get_tree_id, use_args
+from ..util import get_tree_id, tree_exists, use_args
 from . import RefreshProtectedResource, Resource
 
 
@@ -112,11 +112,12 @@ class TokenRefreshResource(RefreshProtectedResource):
 
 
 class TokenCreateOwnerResource(Resource):
-    """Resource for getting a token that allows creating a site owner account."""
+    """Resource for getting a token that allows creating a site admin or tree owner account."""
 
     @limiter.limit("1/second")
     def get(self):
         """Get a token."""
+        # This GET method is deprecated and only kept for backward compatibility!
         if get_all_user_details(tree=None):
             # users already exist!
             abort(405)
@@ -127,3 +128,28 @@ class TokenCreateOwnerResource(Resource):
             },
         )
         return {"access_token": token}
+
+    @limiter.limit("1/second")
+    @use_args(
+        {
+            "tree": fields.Str(required=False),
+        },
+        location="json",
+    )
+    def post(self, args):
+        """Get a token."""
+        tree = args.get("tree")
+        if tree and not tree_exists(tree):
+            abort(404)
+        if get_all_user_details(tree=tree):
+            # users already exist!
+            abort(405)
+        if tree:
+            claims = {
+                CLAIM_LIMITED_SCOPE: SCOPE_CREATE_OWNER,
+                "tree": tree,
+            }
+        else:
+            claims = {CLAIM_LIMITED_SCOPE: SCOPE_CREATE_ADMIN}
+        token = create_access_token(identity="owner", additional_claims=claims)
+        return {"access_token": token}, 201

--- a/gramps_webapi/api/resources/user.py
+++ b/gramps_webapi/api/resources/user.py
@@ -305,6 +305,12 @@ class UserRegisterResource(Resource):
         # do not allow registration if no tree owner account exists!
         if get_number_users(tree=args.get("tree"), roles=(ROLE_OWNER,)) == 0:
             abort(405)
+        if (
+            "tree" in args
+            and current_app.config["TREE"] != TREE_MULTI
+            and args["tree"] != current_app.config["TREE"]
+        ):
+            abort(422)
         if "tree" in args and not tree_exists(args["tree"]):
             abort(422)
         try:
@@ -352,6 +358,12 @@ class UserCreateOwnerResource(LimitedScopeProtectedResource):
             abort(404)
         claims = get_jwt()
         if "tree" in args and not tree_exists(args["tree"]):
+            abort(422)
+        if (
+            "tree" in args
+            and current_app.config["TREE"] != TREE_MULTI
+            and args["tree"] != current_app.config["TREE"]
+        ):
             abort(422)
         if claims[CLAIM_LIMITED_SCOPE] == SCOPE_CREATE_ADMIN:
             if get_number_users() > 0:

--- a/gramps_webapi/auth/const.py
+++ b/gramps_webapi/auth/const.py
@@ -1,7 +1,7 @@
 #
 # Gramps Web API - A RESTful API for the Gramps genealogy program
 #
-# Copyright (C) 2020-2022      David Straub
+# Copyright (C) 2020-2023      David Straub
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -117,3 +117,4 @@ CLAIM_LIMITED_SCOPE = "limited_scope"
 SCOPE_RESET_PW = "reset_password"
 SCOPE_CONF_EMAIL = "confirm_email"
 SCOPE_CREATE_ADMIN = "create_admin"
+SCOPE_CREATE_OWNER = "create_owner"

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -145,13 +145,20 @@ paths:
           description: "Unprocessable Entity: Invalid token."
 
   /token/create_owner/:
-    get:
+    post:
       tags:
       - authentication
-      summary: "Obtain a JWT access token that allows creating an owner account if no other user exists yet."
+      summary: "Obtain a JWT access token that allows creating an admin or owner account if no other user exists yet."
       operationId: getTokenCreateOwner
+      parameters:
+      - name: tree
+        in: body
+        required: false
+        type: string
+        description: "If present, request a token for creating a tree owner. Otherwise, request a token for creating a site admin."
+        example: 0de59650-9bc5-4ee8-957d-4c3eb0851981
       responses:
-        200:
+        201:
           description: "OK: Successful operation."
           schema:
             $ref: "#/definitions/JWTAccessToken"
@@ -376,27 +383,30 @@ paths:
     post:
       tags:
       - users
-      summary: "Create an owner account if no other user exists yet."
+      summary: "Create an admin or owner account if no other user exists yet."
       operationId: createOwner
       parameters:
       - name: user_name
         in: path
         required: true
         type: string
-        description: "The user name for the owner account."
+        description: "The user name for the account."
       - name: user_details
         in: body
         schema:
           type: object
           properties:
             email:
-              description: "The owner's e-mail address."
+              description: "The new user's e-mail address."
               type: string
             full_name:
-              description: "The owner's full name."
+              description: "The new user's full name."
               type: string
             password:
-              description: "The owner's password."
+              description: "The new user's password."
+              type: string
+            tree:
+              description: "The new user's tree (optional)."
               type: string
       responses:
         201:


### PR DESCRIPTION
This generalizes the `/user/<name>/create_owner` and `token/create_owner` to allow also creating a tree owner (if `tree` is specified for a tree without users in a multi-tree setup.