### PR TITLE
Implement transaction undo (fixes #320)

### DIFF
--- a/gramps_webapi/api/resources/util.py
+++ b/gramps_webapi/api/resources/util.py
@@ -70,7 +70,7 @@ from gramps.gen.utils.id import create_id
 from gramps.gen.utils.place import conv_lat_lon
 
 from ...const import DISABLED_IMPORTERS, SEX_FEMALE, SEX_MALE, SEX_UNKNOWN
-from ...types import FilenameOrPath, Handle
+from ...types import FilenameOrPath, Handle, TransactionJson
 from ..media import get_media_handler
 from ..util import get_db_handle, get_tree_from_jwt
 
@@ -1059,7 +1059,7 @@ def _fix_parent_handles(
             db_handle.commit_person(person, trans)
 
 
-def transaction_to_json(transaction: DbTxn) -> List[Dict[str, Any]]:
+def transaction_to_json(transaction: DbTxn) -> TransactionJson:
     """Return a JSON representation of a database transaction."""
     out = []
     for recno in transaction.get_recnos(reverse=False):
@@ -1083,6 +1083,22 @@ def transaction_to_json(transaction: DbTxn) -> List[Dict[str, Any]]:
         }
         out.append(item)
     return out
+
+
+def reverse_transaction(transaction_list: TransactionJson) -> TransactionJson:
+    """Reverse a JSON representation of a database transaction."""
+    transaction_reversed = []
+    type_reversed = {"add": "delete", "delete": "add", "update": "update"}
+    for item in reversed(transaction_list):
+        item_reversed = {
+            "type": type_reversed[item["type"]],
+            "handle": item["handle"],
+            "_class": item["_class"],
+            "old": item["new"],
+            "new": item["old"],
+        }
+        transaction_reversed.append(item_reversed)
+    return transaction_reversed
 
 
 def hash_object(obj: GrampsObject) -> str:

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -4475,6 +4475,11 @@ paths:
       consumes:
         - application/json
       parameters:
+        - name: undo
+          in: query
+          required: false
+          type: boolean
+          description: "If true, apply the inverse of the transaction."
         - in: body
           name: source
           description: The database transaction

--- a/gramps_webapi/types.py
+++ b/gramps_webapi/types.py
@@ -1,7 +1,7 @@
 #
 # Gramps Web API - A RESTful API for the Gramps genealogy program
 #
-# Copyright (C) 2020      David Straub
+# Copyright (C) 2020-2023      David Straub
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
@@ -20,8 +20,9 @@
 """Custom types."""
 
 from pathlib import Path
-from typing import NewType, Union
+from typing import Any, Dict, List, NewType, Union
 
 Handle = NewType("Handle", str)
 GrampsId = NewType("GrampsId", str)
 FilenameOrPath = Union[str, Path]
+TransactionJson = List[Dict[str, Any]]


### PR DESCRIPTION
This adds a boolean `undo` parameter to the `transactions` endpoint. If true, it applies the inverse of the transaction (order reversed, add and delete interchanged, updates inverted). This can be used to allow a simple "undo" for transaction objects return by all the `POST` endpoints.

Fixes #320.