### PR TITLE
Add server info to metadata endpoint; version 1.0

### DIFF
--- a/gramps_webapi/_version.py
+++ b/gramps_webapi/_version.py
@@ -18,4 +18,4 @@
 #
 
 # make sure to match this version with the one in apispec.yaml
-__version__ = "0.7.0"
+__version__ = "1.0.0"

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -8,7 +8,7 @@ info:
 
 
     * More about Gramps and the numerous features it provides for genealogists can be found at https://gramps-project.org
-  version: "0.7.0"  # make sure to match this version with the one in _version.py
+  version: "1.0.0"  # make sure to match this version with the one in _version.py
   license:
     name: "GNU Affero General Public License v3.0"
     url: "http://www.gnu.org/licenses/agpl-3.0.html"

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -9433,6 +9433,18 @@ definitions:
         $ref: "#/definitions/ObjectCounts"
       researcher:
         $ref: "#/definitions/Researcher"
+      server:
+        description: "Information about the server setup."
+        type: object
+        properties:
+          multi_tree:
+            description: "Indicates whether the server is enabled to host multiple family tree databases."
+            type: boolean
+            example: false
+          task_queue:
+            description: "Indicates whether the server is using a task queue for long running operations."
+            type: boolean
+            example: false
       surnames:
         description: "A list of all surnames found in the database."
         type: array


### PR DESCRIPTION
This adds a `server` key with two booleans to the `/api/metadata` endpoint: `multi_tree` indicates whether multi tree support is enabled, `task_queue` whether celery is used. This will be useful for bug reports; we can display system info somewhere in Gramps Web and ask people to copy & paste it into issues.

Finally, this bumps the version to 1.0. While there is no breaking API change, I think it's about time to move from the 0.x numbers.