### PR TITLE
Implement media archive upload endpoint

### DIFF
--- a/gramps_webapi/_version.py
+++ b/gramps_webapi/_version.py
@@ -18,4 +18,4 @@
 #
 
 # make sure to match this version with the one in apispec.yaml
-__version__ = "1.0.0"
+__version__ = "1.1.0"

--- a/gramps_webapi/api/__init__.py
+++ b/gramps_webapi/api/__init__.py
@@ -46,6 +46,7 @@ from .resources.families import FamiliesResource, FamilyResource
 from .resources.file import MediaFileResource
 from .resources.filters import FilterResource, FiltersResource, FiltersResources
 from .resources.holidays import HolidayResource, HolidaysResource
+from .resources.import_media import MediaUploadZipResource
 from .resources.importers import (
     ImporterFileResource,
     ImporterResource,
@@ -342,6 +343,13 @@ register_endpt(
     MediaArchiveFileResource,
     "/media/archive/<string:filename>",
     "media_archive_filename",
+)
+
+# Media import
+register_endpt(
+    MediaUploadZipResource,
+    "/media/archive/upload/zip",
+    "media_archive_upload_zip",
 )
 
 

--- a/gramps_webapi/api/file.py
+++ b/gramps_webapi/api/file.py
@@ -132,7 +132,10 @@ class LocalFileHandler(FileHandler):
 
     def file_exists(self) -> bool:
         """Check if the file exists."""
-        self._check_path()
+        try:
+            self._check_path()
+        except ValueError:
+            return False
         return Path(self.path_abs).is_file()
 
     def get_file_object(self) -> BinaryIO:

--- a/gramps_webapi/api/resources/export_media.py
+++ b/gramps_webapi/api/resources/export_media.py
@@ -17,7 +17,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 
-"""Endpoint for up- and downloading media files."""
+"""Endpoint for creating and downloading media archives."""
 
 import os
 import re

--- a/gramps_webapi/api/resources/import_media.py
+++ b/gramps_webapi/api/resources/import_media.py
@@ -1,0 +1,70 @@
+#
+# Gramps Web API - A RESTful API for the Gramps genealogy program
+#
+# Copyright (C) 2023    David Straub
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+"""Endpoint for importing a media archive."""
+
+import os
+import uuid
+import zipfile
+
+from flask import Response, current_app, jsonify, request
+
+from ...auth.const import PERM_IMPORT_FILE
+from ..auth import require_permissions
+from ..tasks import AsyncResult, import_media_archive, make_task_response, run_task
+from ..util import abort_with_message, get_tree_from_jwt
+from . import ProtectedResource
+
+
+class MediaUploadZipResource(ProtectedResource):
+    """Resource for uploading an archive of media files."""
+
+    def post(self) -> Response:
+        """Upload an archive of media files."""
+        require_permissions([PERM_IMPORT_FILE])
+        request_stream = request.stream
+
+        # we use EXPORT_DIR as location to store the temporary file
+        export_path = current_app.config["EXPORT_DIR"]
+        os.makedirs(export_path, exist_ok=True)
+        file_name = f"{uuid.uuid4()}.zip"
+        file_path = os.path.join(export_path, file_name)
+
+        with open(file_path, "w+b") as ftmp:
+            ftmp.write(request_stream.read())
+
+        if os.path.getsize(file_path) == 0:
+            abort_with_message(400, "Imported file is empty")
+
+        try:
+            with zipfile.ZipFile(file_path) as zip_file:
+                zip_file.namelist()
+        except zipfile.BadZipFile:
+            abort_with_message(400, "The uploaded file is not a valid ZIP file.")
+
+        tree = get_tree_from_jwt()
+        task = run_task(
+            import_media_archive,
+            tree=tree,
+            file_name=file_path,
+            delete=True,
+        )
+        if isinstance(task, AsyncResult):
+            return make_task_response(task)
+        return jsonify(task), 201

--- a/gramps_webapi/api/resources/util.py
+++ b/gramps_webapi/api/resources/util.py
@@ -23,6 +23,9 @@
 
 import json
 import os
+import shutil
+import tempfile
+import zipfile
 from hashlib import sha256
 from http import HTTPStatus
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -42,19 +45,15 @@ from gramps.gen.lib import (
     Citation,
     Event,
     Family,
-    GrampsType,
     Media,
-    Note,
     Person,
     Place,
     PlaceType,
-    Repository,
     Source,
     Span,
-    Tag,
 )
 from gramps.gen.lib.primaryobj import BasicPrimaryObject as GrampsObject
-from gramps.gen.lib.serialize import from_json, to_json
+from gramps.gen.lib.serialize import to_json
 from gramps.gen.plug import BasePluginManager
 from gramps.gen.relationship import get_relationship_calculator
 from gramps.gen.soundex import soundex
@@ -70,9 +69,11 @@ from gramps.gen.utils.grampslocale import GrampsLocale
 from gramps.gen.utils.id import create_id
 from gramps.gen.utils.place import conv_lat_lon
 
+from ...auth import set_tree_usage
 from ...const import DISABLED_IMPORTERS, SEX_FEMALE, SEX_MALE, SEX_UNKNOWN
 from ...types import FilenameOrPath, Handle, TransactionJson
-from ..media import get_media_handler
+from ..file import get_checksum
+from ..media import check_quota_media, get_media_handler
 from ..util import abort_with_message, get_db_handle, get_tree_from_jwt
 
 pd = PlaceDisplay()
@@ -1208,4 +1209,97 @@ def dry_run_import(
         "repositories": db_handle.get_number_of_repositories(),
         "notes": db_handle.get_number_of_notes(),
         "tags": db_handle.get_number_of_tags(),
+    }
+
+
+def run_import_media_archive(
+    tree: str,
+    db_handle: DbReadBase,
+    file_name: FilenameOrPath,
+    delete: bool = True,
+) -> Dict[str, int]:
+    """Import a media archive file."""
+    media_handler = get_media_handler(db_handle, tree=tree)
+
+    # create a dict {checksum: [(handle1, path), (handle2, path2), ...], ...}
+    # of missing files
+    handles = db_handle.get_media_handles()
+    objects = [db_handle.get_media_from_handle(handle) for handle in handles]
+    objects_existing = media_handler.filter_existing_files(objects, db_handle=db_handle)
+    handles_existing = set(obj.handle for obj in objects_existing)
+    objects_missing = [obj for obj in objects if obj.handle not in handles_existing]
+
+    checksums_handles: Dict[str, List[Tuple[str, str, str]]] = {}
+    for obj in objects_missing:
+        if obj.checksum not in checksums_handles:
+            checksums_handles[obj.checksum] = []
+        obj_details = (obj.handle, obj.get_path(), obj.get_mime_type())
+        checksums_handles[obj.checksum].append(obj_details)
+    if len(checksums_handles) == 0:
+        # no missing files
+        # delete ZIP file
+        if delete:
+            os.remove(file_name)
+        return {"missing": 0, "uploaded": 0, "failures": 0}
+
+    total_size = 0
+    with zipfile.ZipFile(file_name, "r") as zip_file:
+        # compute file size
+        for file_info in zip_file.infolist():
+            total_size += file_info.file_size
+
+        # check disk usage
+        disk_usage = shutil.disk_usage(file_name)
+        if total_size > disk_usage.free:
+            raise ValueError("Not enough free space on disk")
+
+        # extract
+        temp_dir = tempfile.mkdtemp()
+        zip_file.extractall(temp_dir)
+
+    # delete ZIP file
+    if delete:
+        os.remove(file_name)
+
+    to_upload = {}
+    # walk extracted files
+    for root, _, files in os.walk(temp_dir):
+        for name in files:
+            file_path = os.path.join(root, name)
+            with open(file_path, "rb") as f:
+                checksum = get_checksum(f)
+                if checksum in checksums_handles and checksum not in to_upload:
+                    to_upload[checksum] = (file_path, os.path.getsize(file_path))
+
+    if len(to_upload) == 0:
+        # no files to upload
+
+        # delete extracted temp files
+        shutil.rmtree(temp_dir)
+
+        return {"missing": len(checksums_handles), "uploaded": 0, "failures": 0}
+
+    upload_size = sum([file_size for (file_path, file_size) in to_upload.values()])
+    check_quota_media(to_add=upload_size, tree=tree)
+
+    num_failures = 0
+    for checksum, (file_path, file_size) in to_upload.items():
+        for handle, media_path, mime in checksums_handles[checksum]:
+            with open(file_path, "rb") as f:
+                try:
+                    media_handler.upload_file(f, checksum, mime, path=media_path)
+                except Exception:
+                    num_failures += 1
+
+    # delete extracted temp files
+    shutil.rmtree(temp_dir)
+
+    # update media usage
+    usage_media = media_handler.get_media_size(db_handle=db_handle)
+    set_tree_usage(tree, usage_media=usage_media)
+
+    return {
+        "missing": len(checksums_handles),
+        "uploaded": len(to_upload) - num_failures,
+        "failures": num_failures,
     }

--- a/gramps_webapi/api/tasks.py
+++ b/gramps_webapi/api/tasks.py
@@ -33,7 +33,7 @@ from .emails import email_confirm_email, email_new_user, email_reset_pw
 from .export import prepare_options, run_export
 from .media import get_media_handler
 from .report import run_report
-from .resources.util import dry_run_import, run_import
+from .resources.util import dry_run_import, run_import, run_import_media_archive
 from .util import (
     check_quota_people,
     get_config,
@@ -201,3 +201,17 @@ def export_media(tree: str, view_private: bool) -> Dict[str, Union[str, int]]:
         "url": f"/api/media/archive/{file_name}",
         "file_size": file_size,
     }
+
+
+@shared_task()
+def import_media_archive(tree: str, file_name: str, delete: bool = True):
+    """Import a media archive."""
+    # check_quota_people(to_add=object_counts["people"], tree=tree)
+    db_handle = get_db_outside_request(tree=tree, view_private=True, readonly=True)
+    result = run_import_media_archive(
+        tree=tree,
+        db_handle=db_handle,
+        file_name=file_name,
+        delete=delete,
+    )
+    return result

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -3927,6 +3927,29 @@ paths:
         422:
           description: "Unprocessable Entity: Invalid or bad parameter provided."
 
+  /media/archive/upload/zip:
+    post:
+      tags:
+      - media
+      summary: "Upload a zipped media file archive."
+      operationId: uploadMediaFileArchive
+      security:
+        - Bearer: []
+      responses:
+        201:
+          description: "OK: Successful operation."
+        202:
+          description: "Accepted: import will be processed in the background."
+          schema:
+            type: object
+            properties:
+              task:
+                $ref: "#/definitions/TaskReference"
+        401:
+          description: "Unauthorized: Missing authorization header."
+        403:
+          description: "Unauthorized: insufficient permissions."
+
 ##############################################################################
 # Endpoint - Notes
 ##############################################################################

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -8,7 +8,7 @@ info:
 
 
     * More about Gramps and the numerous features it provides for genealogists can be found at https://gramps-project.org
-  version: "1.0.0"  # make sure to match this version with the one in _version.py
+  version: "1.1.0"  # make sure to match this version with the one in _version.py
   license:
     name: "GNU Affero General Public License v3.0"
     url: "http://www.gnu.org/licenses/agpl-3.0.html"

--- a/tests/test_endpoints/test_import_media.py
+++ b/tests/test_endpoints/test_import_media.py
@@ -84,7 +84,6 @@ class TestImporterMedia(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.dbman.remove_database(cls.name)
         shutil.rmtree(cls.tmp_dir)
 
     def test_import_media(self):

--- a/tests/test_endpoints/test_import_media.py
+++ b/tests/test_endpoints/test_import_media.py
@@ -55,6 +55,7 @@ class TestImporterMedia(unittest.TestCase):
         os.mkdir(cls.db_dir)
         cls.export_dir = os.path.join(cls.tmp_dir, "export")
         os.mkdir(cls.export_dir)
+        cls.old_grampshome = os.environ["GRAMPSHOME"]
         os.environ["GRAMPSHOME"] = cls.db_dir
         cls.media_dir = os.path.join(cls.tmp_dir, "media")
         os.mkdir(cls.media_dir)
@@ -85,6 +86,7 @@ class TestImporterMedia(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         shutil.rmtree(cls.tmp_dir)
+        os.environ["GRAMPSHOME"] = cls.old_grampshome
 
     def test_import_media(self):
         """Test that importers are loaded also for a fresh db."""

--- a/tests/test_endpoints/test_import_media.py
+++ b/tests/test_endpoints/test_import_media.py
@@ -1,0 +1,148 @@
+#
+# Gramps Web API - A RESTful API for the Gramps genealogy program
+#
+# Copyright (C) 2023      David M. Straub
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+"""Tests for the /api/media/archive/upload/zip endpoint."""
+
+import os
+import shutil
+import tempfile
+import unittest
+import zipfile
+from typing import Dict
+from unittest.mock import patch
+
+from gramps.cli.clidbman import CLIDbManager
+from gramps.gen.dbstate import DbState
+
+from gramps_webapi.app import create_app
+from gramps_webapi.auth import add_user, user_db
+from gramps_webapi.auth.const import ROLE_OWNER
+from gramps_webapi.const import ENV_CONFIG_FILE, TEST_EMPTY_GRAMPS_AUTH_CONFIG
+
+
+def get_headers(client, user: str, password: str) -> Dict[str, str]:
+    """Get the auth headers for a specific user."""
+    rv = client.post("/api/token/", json={"username": user, "password": password})
+    access_token = rv.json["access_token"]
+    return {"Authorization": "Bearer {}".format(access_token)}
+
+
+class TestImporterMedia(unittest.TestCase):
+    """Test cases for the /api/archive/upload/zip endpoint."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Test class setup."""
+        cls.name = "empty"
+        cls.tmp_dir = tempfile.mkdtemp()
+        cls.db_dir = os.path.join(cls.tmp_dir, "db")
+        os.mkdir(cls.db_dir)
+        cls.export_dir = os.path.join(cls.tmp_dir, "export")
+        os.mkdir(cls.export_dir)
+        os.environ["GRAMPSHOME"] = cls.db_dir
+        cls.media_dir = os.path.join(cls.tmp_dir, "media")
+        os.mkdir(cls.media_dir)
+        cls.dbman = CLIDbManager(DbState())
+        cls.dbpath, _name = cls.dbman.create_new_db_cli(cls.name, dbid="sqlite")
+        cls.dbman.create_new_db_cli(cls.name, dbid="sqlite")
+        with patch.dict(
+            "os.environ",
+            {
+                ENV_CONFIG_FILE: TEST_EMPTY_GRAMPS_AUTH_CONFIG,
+                "GRAMPSWEB_TREE": "empty",
+            },
+        ):
+            cls.test_app = create_app(
+                {"EXPORT_DIR": cls.export_dir, "MEDIA_BASE_DIR": cls.media_dir}
+            )
+        cls.test_app.config["TESTING"] = True
+        cls.client = cls.test_app.test_client()
+        cls.tree = os.path.basename(cls.dbpath)
+        with cls.test_app.app_context():
+            user_db.create_all()
+            add_user(
+                name="owner",
+                password="owner",
+                role=ROLE_OWNER,
+            )
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.dbman.remove_database(cls.name)
+        shutil.rmtree(cls.tmp_dir)
+
+    def test_import_media(self):
+        """Test that importers are loaded also for a fresh db."""
+        headers = get_headers(self.client, "owner", "owner")
+        files = ["f1.jpg", "f2.jpg", "f3.jpg", "f4.jpg"]
+        # write 4 random files with 1 kB, 2 kB, 3 kB, 4 kB
+        for i, filename in enumerate(files):
+            path = os.path.join(self.tmp_dir, filename)
+            with open(path, "wb") as f:
+                f.write(os.urandom((i + 1) * 1000))
+        # upload 3 files
+        for i, filename in enumerate(["f1.jpg", "f2.jpg", "f3.jpg"]):
+            path = os.path.join(self.tmp_dir, filename)
+            with open(path, "rb") as f:
+                rv = self.client.post(
+                    "/api/media/",
+                    data=f.read(),
+                    headers=headers,
+                    content_type="image/jpeg",
+                )
+                assert rv.status_code == 201
+        rv = self.client.get("/api/media/", headers=headers)
+        assert rv.status_code == 200
+        media_objects = rv.json
+        assert len(media_objects) == 3
+        rv = self.client.get("/api/trees/-", headers=headers)
+        assert rv.status_code == 200
+        assert rv.json["usage_media"] == 1000 + 2000 + 3000
+        # delete f1 & f2
+        for obj in media_objects:
+            if obj["gramps_id"] in ["O0000", "O0001"]:
+                checksum = obj["checksum"]
+                path = os.path.join(self.media_dir, f"{checksum}.jpg")
+                os.remove(path)
+        rv = self.client.get("/api/media/?filemissing=1", headers=headers)
+        assert rv.status_code == 200
+        assert len(rv.json) == 2
+
+        # zip f2 & f3, upload
+        zip_path = os.path.join(self.tmp_dir, "zip1.zip")
+        with zipfile.ZipFile(zip_path, "w") as fzip:
+            for filename in ["f2.jpg", "f3.jpg"]:
+                path = os.path.join(self.tmp_dir, filename)
+                fzip.write(path)
+        with open(zip_path, "rb") as f:
+            rv = self.client.post(
+                "/api/media/archive/upload/zip", headers=headers, data=f.read()
+            )
+            assert rv.status_code == 201
+        zip_files = [fn for fn in os.listdir(self.export_dir) if fn.endswith(".zip")]
+        assert len(zip_files) == 0  # temporary file deleted
+        assert rv.json["missing"] == 2
+        assert rv.json["uploaded"] == 1
+        assert rv.json["failures"] == 0
+        rv = self.client.get("/api/media/?filemissing=1", headers=headers)
+        assert rv.status_code == 200
+        assert len(rv.json) == 1
+        rv = self.client.get("/api/trees/-", headers=headers)
+        assert rv.status_code == 200
+        assert rv.json["usage_media"] == 2000 + 3000

--- a/tests/test_endpoints/test_import_media.py
+++ b/tests/test_endpoints/test_import_media.py
@@ -49,14 +49,12 @@ class TestImporterMedia(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """Test class setup."""
-        cls.name = "empty"
+        cls.name = "empty-import-media"
         cls.tmp_dir = tempfile.mkdtemp()
         cls.db_dir = os.path.join(cls.tmp_dir, "db")
         os.mkdir(cls.db_dir)
         cls.export_dir = os.path.join(cls.tmp_dir, "export")
         os.mkdir(cls.export_dir)
-        cls.old_grampshome = os.environ["GRAMPSHOME"]
-        os.environ["GRAMPSHOME"] = cls.db_dir
         cls.media_dir = os.path.join(cls.tmp_dir, "media")
         os.mkdir(cls.media_dir)
         cls.dbman = CLIDbManager(DbState())
@@ -86,7 +84,7 @@ class TestImporterMedia(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         shutil.rmtree(cls.tmp_dir)
-        os.environ["GRAMPSHOME"] = cls.old_grampshome
+        cls.dbman.remove_database(cls.name)
 
     def test_import_media(self):
         """Test that importers are loaded also for a fresh db."""

--- a/tests/test_endpoints/test_import_media.py
+++ b/tests/test_endpoints/test_import_media.py
@@ -64,7 +64,7 @@ class TestImporterMedia(unittest.TestCase):
             "os.environ",
             {
                 ENV_CONFIG_FILE: TEST_EMPTY_GRAMPS_AUTH_CONFIG,
-                "GRAMPSWEB_TREE": "empty",
+                "GRAMPSWEB_TREE": cls.name,
             },
         ):
             cls.test_app = create_app(

--- a/tests/test_endpoints/test_importers.py
+++ b/tests/test_endpoints/test_importers.py
@@ -107,7 +107,7 @@ class TestImportersExtensionFile(unittest.TestCase):
             "os.environ",
             {
                 ENV_CONFIG_FILE: TEST_EMPTY_GRAMPS_AUTH_CONFIG,
-                "TREE": "empty",
+                "TREE": cls.name,
             },
         ):
             cls.test_app = create_app()


### PR DESCRIPTION
This adds a new endpoint `/api/media/archive/upload/zip`. Posting a ZIP file with media files to it, the checksums of the zipped files will be compared to all checksums of _missing_ media files for existing media objects. In case of a match, the file is stored in the media directory.

The use case is a tree owner uploading a Gramps XML file to a pristine tree and subsequently uploading the media files.