### PR TITLE
Option to force a transaction

### DIFF
--- a/gramps_webapi/api/resources/transactions.py
+++ b/gramps_webapi/api/resources/transactions.py
@@ -55,6 +55,7 @@ class TransactionsResource(ProtectedResource):
     @use_args(
         {
             "undo": fields.Boolean(load_default=False),
+            "force": fields.Boolean(load_default=False),
         },
         location="query",
     )
@@ -83,7 +84,9 @@ class TransactionsResource(ProtectedResource):
                     trans_type = item["type"]
                     handle = item["handle"]
                     old_data = item["old"]
-                    if not self.old_unchanged(db_handle, class_name, handle, old_data):
+                    if not args["force"] and not self.old_unchanged(
+                        db_handle, class_name, handle, old_data
+                    ):
                         abort_with_message(409, "Object has changed")
                     new_data = item["new"]
                     if new_data:

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -4513,6 +4513,11 @@ paths:
           required: false
           type: boolean
           description: "If true, apply the inverse of the transaction."
+        - name: force
+          in: query
+          required: false
+          type: boolean
+          description: "If true, force applying the transaction even if objects have been modified."
         - in: body
           name: source
           description: The database transaction


### PR DESCRIPTION
This adds an optional boolean parameter `force` to the transactions endpoint. If true (default false), transactions are applied even if objects have been modified (if false, a 409 is raised in this case).

This is useful for the sync addon in case there are inconsistencies with the remote database. This can lead to false 409s since the object exported as XML and the object in the database can differ, which looks like an object modification.