### PR TITLE
Do not include surname list in metadata by default

### DIFF
--- a/gramps_webapi/api/resources/metadata.py
+++ b/gramps_webapi/api/resources/metadata.py
@@ -20,16 +20,17 @@
 
 """Metadata API resource."""
 
-from flask import current_app, Response
+from flask import Response, current_app
 from gramps.cli.clidbman import CLIDbManager
 from gramps.gen.const import ENV, GRAMPS_LOCALE
 from gramps.gen.db.base import DbReadBase
 from gramps.gen.dbstate import DbState
 from gramps.gen.utils.grampslocale import INCOMPLETE_TRANSLATIONS
+from webargs import fields
 
 from gramps_webapi.const import TREE_MULTI, VERSION
 
-from ..util import get_db_handle
+from ..util import get_db_handle, use_args
 from . import ProtectedResource
 from .emit import GrampsJSONEncoder
 
@@ -42,7 +43,13 @@ class MetadataResource(ProtectedResource, GrampsJSONEncoder):
         """Get the database instance."""
         return get_db_handle()
 
-    def get(self) -> Response:
+    @use_args(
+        {
+            "surnames": fields.Boolean(load_default=False),
+        },
+        location="query",
+    )
+    def get(self, args) -> Response:
         """Get active database and application related metadata information."""
         catalog = GRAMPS_LOCALE.get_language_dict()
         for entry in catalog:
@@ -100,8 +107,9 @@ class MetadataResource(ProtectedResource, GrampsJSONEncoder):
             },
             "researcher": db_handle.get_researcher(),
             "server": {"multi_tree": is_multi_tree, "task_queue": has_task_queue},
-            "surnames": db_handle.get_surname_list(),
         }
+        if args["surnames"]:
+            result["surnames"] = (db_handle.get_surname_list(),)
         data = db_handle.get_summary()
         db_version_key = GRAMPS_LOCALE.translation.sgettext("Database version")
         db_module_key = GRAMPS_LOCALE.translation.sgettext("Database module version")

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -6701,6 +6701,13 @@ paths:
       operationId: getMetadata
       security:
         - Bearer: []
+      parameters:
+      - name: surnames
+        in: query
+        required: false
+        type: boolean
+        default: false
+        description: "If true, also include the surname list in the result."
       responses:
         200:
           description: "OK: Successful operation."


### PR DESCRIPTION
The surname list makes the metadata endpoint very slow for large databases, but is currently not used at all in Gramps Web.

So this PR adds a boolean query parameter to display the surname list, but makes it false by default. So the change is backward compatible with respect to Gramps Web (so older frontends don't break with newer backends).