### PR TITLE
Add DNA segment map endpoint

### DIFF
--- a/gramps_webapi/api/__init__.py
+++ b/gramps_webapi/api/__init__.py
@@ -60,6 +60,7 @@ from .resources.name_groups import NameGroupsResource
 from .resources.notes import NoteResource, NotesResource
 from .resources.objects import CreateObjectsResource
 from .resources.people import PeopleResource, PersonResource
+from .resources.dna import PersonDnaMatchesResource
 from .resources.places import PlaceResource, PlacesResource
 from .resources.relations import RelationResource, RelationsResource
 from .resources.reports import (
@@ -133,6 +134,11 @@ register_endpt(
     PersonTimelineResource, "/people/<string:handle>/timeline", "person-timeline"
 )
 register_endpt(PersonResource, "/people/<string:handle>", "person")
+register_endpt(
+    PersonDnaMatchesResource,
+    "/people/<string:handle>/dna/matches",
+    "person-dna-matches",
+)
 register_endpt(PeopleResource, "/people/", "people")
 # Families
 register_endpt(

--- a/gramps_webapi/api/resources/dna.py
+++ b/gramps_webapi/api/resources/dna.py
@@ -1,0 +1,208 @@
+#
+# Gramps Web API - A RESTful API for the Gramps genealogy program
+#
+# Copyright (C) 2020       Nick Hall
+# Copyright (C) 2020-2023  Gary Griffin
+# Copyright (C) 2023       David Straub
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+"""DNA resources."""
+
+from typing import Any, Dict, List, Optional, Union
+
+from flask import abort
+from gramps.gen.const import GRAMPS_LOCALE as glocale
+from gramps.gen.db.base import DbReadBase
+from gramps.gen.errors import HandleError
+from gramps.gen.lib import Person, PersonRef
+from gramps.gen.relationship import get_relationship_calculator
+from gramps.gen.utils.grampslocale import GrampsLocale
+from webargs import fields, validate
+
+from ...types import Handle
+from ..util import get_db_handle, get_locale_for_language, use_args
+from . import ProtectedResource
+
+SIDE_UNKNOWN = "U"
+SIDE_MATERNAL = "M"
+SIDE_PATERNAL = "P"
+
+Segment = Dict[str, Union[float, int, str]]
+
+
+class PersonDnaMatchesResource(ProtectedResource):
+    """Resource for getting DNA match data for a person."""
+
+    @use_args(
+        {
+            "locale": fields.Str(
+                load_default=None, validate=validate.Length(min=2, max=5)
+            ),
+        },
+        location="query",
+    )
+    def get(self, args: Dict, handle: str):
+        """Get the DNA match data."""
+        db_handle = get_db_handle()
+        try:
+            person = db_handle.get_person_from_handle(handle)
+        except HandleError:
+            abort(404)
+        locale = get_locale_for_language(args["locale"], default=True)
+        matches = []
+        for association in person.get_person_ref_list():
+            if association.get_relation() == "DNA":
+                match_data = get_match_data(
+                    db_handle=db_handle,
+                    person=person,
+                    association=association,
+                    locale=locale,
+                )
+                matches.append(match_data)
+        return matches
+
+
+def get_match_data(
+    db_handle: DbReadBase,
+    person: Person,
+    association: PersonRef,
+    locale: GrampsLocale = glocale,
+) -> Dict[str, Any]:
+    """Get the DNA match data in the appropriate format."""
+    relationship = get_relationship_calculator(reinit=True, clocale=locale)
+    associate = db_handle.get_person_from_handle(association.ref)
+    data, _ = relationship.get_relationship_distance_new(
+        db_handle,
+        person,
+        associate,
+        all_families=False,
+        all_dist=True,
+        only_birth=True,
+    )
+    if data[0][0] <= 0:  # Unrelated
+        side = SIDE_UNKNOWN
+    elif data[0][0] == 1:  # parent / child
+        if db_handle.get_person_from_handle(data[0][1]).gender == 0:
+            side = SIDE_MATERNAL
+        else:
+            side = SIDE_PATERNAL
+    elif (
+        len(data) > 1 and data[0][0] == data[1][0] and data[0][2][0] != data[1][2][0]
+    ):  # shares both parents
+        side = SIDE_UNKNOWN
+    else:
+        translate_sides = {"m": SIDE_MATERNAL, "f": SIDE_PATERNAL}
+        side = translate_sides[data[0][2][0]]
+
+    segments = []
+
+    # Get Notes attached to Association
+    note_handles = association.get_note_list()
+
+    # Get Notes attached to Citation which is attached to the Association
+    for citation_handle in association.get_citation_list():
+        citation = db_handle.get_citation_from_handle(citation_handle)
+        note_handles += citation.get_note_list()
+
+    for note_handle in note_handles:
+        segments += get_segments_from_note(db_handle, handle=note_handle, side=side)
+
+    rel_strings, common_ancestors = relationship.get_all_relationships(
+        db_handle, person, associate
+    )
+    if len(rel_strings) == 0:
+        rel_string = ""
+        ancestor_handles = []
+    else:
+        rel_string = rel_strings[0]
+        ancestor_handles = common_ancestors[0]
+
+    return {
+        "handle": association.ref,
+        "segments": segments,
+        "relation": rel_string,
+        "ancestor_handles": ancestor_handles,
+    }
+
+
+def get_segments_from_note(
+    db_handle: DbReadBase, handle: Handle, side: Optional[str] = None
+) -> List[Segment]:
+    """Get the segements from a note handle."""
+    note = db_handle.get_note_from_handle(handle)
+    segments = []
+    for line in note.get().split("\n"):
+        data = parse_line(line, side=side)
+        if data:
+            segments.append(data)
+    return segments
+
+
+def parse_line(line: str, side: Optional[str] = None) -> Optional[Segment]:
+    """Parse a line from the CSV/TSV data and return a dictionary."""
+    if "\t" in line:
+        # Tabs are the field separators. Now determine THOUSEP and RADIXCHAR.
+        # Use Field 2 (Stop Pos) to see if there are THOUSEP there. Use Field 3
+        # (SNPs) to see if there is a radixchar
+        field = line.split("\t")
+        if "," in field[2]:
+            line = line.replace(",", "")
+        elif "." in field[2]:
+            line = line.replace(".", "")
+        if "," in field[3]:
+            line = line.replace(",", ".")
+        line = line.replace("\t", ",")
+    field = line.split(",")
+    if len(field) < 4:
+        return None
+    chromo = field[0].strip()
+    start = get_base(field[1])
+    stop = get_base(field[2])
+    try:
+        cms = float(field[3])
+    except (ValueError, TypeError, IndexError):
+        return None
+    try:
+        snp = int(field[4])
+    except (ValueError, TypeError, IndexError):
+        snp = 0
+    seg_comment = ""
+    side = side or SIDE_UNKNOWN
+    if len(field) > 5:
+        if field[5] in {SIDE_MATERNAL, SIDE_PATERNAL, SIDE_UNKNOWN}:
+            side = field[5].strip()
+        else:
+            seg_comment = field[5].strip()
+    return {
+        "chromosome": chromo,
+        "start": start,
+        "stop": stop,
+        "side": side,
+        "cM": cms,
+        "SNPs": snp,
+        "comment": seg_comment,
+    }
+
+
+def get_base(num: str) -> int:
+    """Get the number as int."""
+    try:
+        return int(num)
+    except (ValueError, TypeError):
+        try:
+            return int(float(num) * 1000000)
+        except (ValueError, TypeError):
+            return 0

--- a/gramps_webapi/api/resources/dna.py
+++ b/gramps_webapi/api/resources/dna.py
@@ -34,6 +34,7 @@ from webargs import fields, validate
 
 from ...types import Handle
 from ..util import get_db_handle, get_locale_for_language, use_args
+from .util import get_person_profile_for_handle
 from . import ProtectedResource
 
 SIDE_UNKNOWN = "U"
@@ -129,12 +130,18 @@ def get_match_data(
     else:
         rel_string = rel_strings[0]
         ancestor_handles = common_ancestors[0]
-
+    ancestor_profiles = [
+        get_person_profile_for_handle(
+            db_handle=db_handle, handle=handle, args=[], locale=locale
+        )
+        for handle in ancestor_handles
+    ]
     return {
         "handle": association.ref,
         "segments": segments,
         "relation": rel_string,
         "ancestor_handles": ancestor_handles,
+        "ancestor_profiles": ancestor_profiles,
     }
 
 

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -10186,6 +10186,13 @@ definitions:
         items:
           type: string
           example: ORFKQC4KLWEGTGR19L
+      ancestor_profiles:
+        description: The profiles of the latest common ancestors
+        type: array
+        items:
+          type: array
+          items:
+            $ref: "#/definitions/PersonProfile"
       segments:
         description: Details about each maching chromosome segment.
         type: array

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -10206,11 +10206,11 @@ definitions:
         example: "11"
       start:
         description: The starting number for the segment location.
-        type: int
+        type: integer
         example: 56950055
       stop:
         description: The ending number for the segment location.
-        type: int
+        type: integer
         example: 64247327
       side:
         description: Whether the match is one the maternal (M), paternal (P), or unkown (U) side.
@@ -10222,7 +10222,7 @@ definitions:
         example: 10.9
       SNPs:
         description: Number of matching SNPs (Single Nucleotide Polymorphisms) in the segment.
-        type: int
+        type: integer
         example: 1404
       comment:
         description: A comment about the segment

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -1265,6 +1265,40 @@ paths:
           description: "Unprocessable Entity: Invalid or bad parameter provided."
 
 
+
+  /people/{handle}/dna/matches:
+    get:
+      tags:
+      - people
+      summary: "Get DNA matches for a specific person."
+      operationId: getPersonDnaMatches
+      security:
+        - Bearer: []
+      parameters:
+      - name: handle
+        in: path
+        required: true
+        type: string
+        minLength: 8
+        description: "The unique identifier for a person."
+      - name: locale
+        in: query
+        required: false
+        type: string
+        description: "Specifies the locale to be used where applicable if one other than the current default is desired. Should be a valid language code from the available list of translations."
+      responses:
+        200:
+          description: "OK: Successful operation."
+          schema:
+            type: array
+            items:
+              $ref: "#/definitions/DnaMatch"
+        401:
+          description: "Unauthorized: Missing authorization header."
+        422:
+          description: "Unprocessable Entity: Invalid or bad parameter provided."
+
+
 ##############################################################################
 # Endpoint - Families
 ##############################################################################
@@ -10129,6 +10163,70 @@ definitions:
         description: "Type of the event."
         type: string
         example: "Birth"
+
+
+##############################################################################
+# Model - DnaMatch
+##############################################################################
+
+  DnaMatch:
+    type: object
+    properties:
+      handle:
+        description: The handle of the matching person.
+        type: string
+        example: 9BXKQC1PVLPYFMD6IX
+      relation:
+        description: The relationship to the matching person
+        type: string
+        example: "first cousin"
+      ancestor_handles:
+        description: The handles of the latest common ancestors
+        type: array
+        items:
+          type: string
+          example: ORFKQC4KLWEGTGR19L
+      segments:
+        description: Details about each maching chromosome segment.
+        type: array
+        items:
+          $ref: "#/definitions/DnaSegment"
+
+
+##############################################################################
+# Model - DnaSegment
+##############################################################################
+
+  DnaSegment:
+    type: object
+    properties:
+      chromosome:
+        description: The handle of the matching person.
+        type: string
+        example: "11"
+      start:
+        description: The starting number for the segment location.
+        type: int
+        example: 56950055
+      stop:
+        description: The ending number for the segment location.
+        type: int
+        example: 64247327
+      side:
+        description: Whether the match is one the maternal (M), paternal (P), or unkown (U) side.
+        type: string
+        example: P
+      cM:
+        description: The Genetic Distance (otherwise known as the number of centiMorgans) in the segment.
+        type: number
+        example: 10.9
+      SNPs:
+        description: Number of matching SNPs (Single Nucleotide Polymorphisms) in the segment.
+        type: int
+        example: 1404
+      comment:
+        description: A comment about the segment
+        type: string
 
 ##############################################################################
 # Model - TimelinePersonProfile

--- a/tests/test_endpoints/test_dna.py
+++ b/tests/test_endpoints/test_dna.py
@@ -1,0 +1,325 @@
+#
+# Gramps Web API - A RESTful API for the Gramps genealogy program
+#
+# Copyright (C) 2023      David Straub
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+"""Tests for the /people/<handle>/dna/ endpoints."""
+
+import os
+import unittest
+import uuid
+from typing import Dict
+from unittest.mock import patch
+
+from gramps.cli.clidbman import CLIDbManager
+from gramps.gen.const import GRAMPS_LOCALE as glocale
+from gramps.gen.dbstate import DbState
+
+from gramps_webapi.app import create_app
+from gramps_webapi.auth import add_user, user_db
+from gramps_webapi.auth.const import (
+    ROLE_CONTRIBUTOR,
+    ROLE_EDITOR,
+    ROLE_GUEST,
+    ROLE_OWNER,
+)
+from gramps_webapi.const import ENV_CONFIG_FILE, TEST_AUTH_CONFIG
+
+
+match1 = """chromosome,start,end,cMs,SNP
+1,56950055,64247327,10.9,1404
+5,850055,950055,12,1700
+"""
+match2 = """chromosome	start	end	cMs	SNP	Side
+2	56950055	64247327	10.9	1404	M"""
+match3 = """chromosome,start,end,cMs
+X,56950055,64247327,10.9"""
+
+
+def get_headers(client, user: str, password: str) -> Dict[str, str]:
+    """Get the auth headers for a specific user."""
+    rv = client.post("/api/token/", json={"username": user, "password": password})
+    access_token = rv.json["access_token"]
+    return {"Authorization": "Bearer {}".format(access_token)}
+
+
+def make_handle() -> str:
+    """Make a new valid handle."""
+    return str(uuid.uuid4())
+
+
+def get_headers(client, user: str, password: str) -> Dict[str, str]:
+    """Get the auth headers for a specific user."""
+    rv = client.post("/api/token/", json={"username": user, "password": password})
+    access_token = rv.json["access_token"]
+    return {"Authorization": "Bearer {}".format(access_token)}
+
+
+class TestDnaMatches(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.name = "Test Web API DNA"
+        cls.dbman = CLIDbManager(DbState())
+        dbpath, _ = cls.dbman.create_new_db_cli(cls.name, dbid="sqlite")
+        tree = os.path.basename(dbpath)
+        with patch.dict("os.environ", {ENV_CONFIG_FILE: TEST_AUTH_CONFIG}):
+            cls.app = create_app()
+        cls.app.config["TESTING"] = True
+        cls.client = cls.app.test_client()
+        with cls.app.app_context():
+            user_db.create_all()
+            add_user(name="user", password="123", role=ROLE_GUEST, tree=tree)
+            add_user(name="admin", password="123", role=ROLE_OWNER, tree=tree)
+            add_user(
+                name="contributor", password="123", role=ROLE_CONTRIBUTOR, tree=tree
+            )
+            add_user(name="editor", password="123", role=ROLE_EDITOR, tree=tree)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.dbman.remove_database(cls.name)
+
+    def test_without_token(self):
+        """Test without token."""
+        rv = self.client.get("/api/people/nope/dna/matches")
+        assert rv.status_code == 401
+
+    def test_person_not_found(self):
+        """Test with non-existing person."""
+        headers = get_headers(self.client, "user", "123")
+        rv = self.client.get("/api/people/nope/dna/matches", headers=headers)
+        assert rv.status_code == 404
+
+    def test_no_assoc(self):
+        """Test without association."""
+        headers = get_headers(self.client, "admin", "123")
+        person = {
+            "primary_name": {
+                "surname_list": [
+                    {
+                        "_class": "Surname",
+                        "surname": "Doe",
+                    }
+                ],
+                "first_name": "John",
+            },
+            "gender": 1,
+        }
+        rv = self.client.post("/api/people/", json=person, headers=headers)
+        assert rv.status_code == 201
+        handle = rv.json[0]["handle"]
+        rv = self.client.get(f"/api/people/{handle}/dna/matches", headers=headers)
+        assert rv.status_code == 200
+        assert rv.json == []
+
+    def test_one(self):
+        """Test without association."""
+        headers = get_headers(self.client, "admin", "123")
+        handle_p1 = make_handle()
+        handle_p2 = make_handle()
+        handle_p3 = make_handle()
+        handle_p4 = make_handle()
+        handle_grandf = make_handle()
+        handle_f1 = make_handle()
+        handle_f2 = make_handle()
+        handle_f3 = make_handle()
+        handle_n1 = make_handle()
+        handle_n2 = make_handle()
+        handle_n3 = make_handle()
+        handle_c = make_handle()
+        objects = [
+            {
+                "_class": "Person",
+                "handle": handle_p1,
+                "primary_name": {
+                    "_class": "Name",
+                    "surname_list": [
+                        {
+                            "_class": "Surname",
+                            "surname": "Doe",
+                        }
+                    ],
+                    "first_name": "John",
+                },
+                "gender": 1,
+                "person_ref_list": [
+                    {
+                        "_class": "PersonRef",
+                        "note_list": [handle_n1, handle_n2],
+                        "citation_list": [handle_c],
+                        "rel": "DNA",
+                        "ref": handle_p2,
+                    }
+                ],
+            },
+            {
+                "_class": "Person",
+                "handle": handle_p2,
+                "primary_name": {
+                    "_class": "Name",
+                    "surname_list": [
+                        {
+                            "_class": "Surname",
+                            "surname": "Mustermann",
+                        }
+                    ],
+                    "first_name": "Max",
+                },
+                "gender": 1,
+            },
+            {
+                "_class": "Person",
+                "handle": handle_p3,
+                "primary_name": {
+                    "_class": "Name",
+                    "surname_list": [
+                        {
+                            "_class": "Surname",
+                            "surname": "Mustermann",
+                        }
+                    ],
+                    "first_name": "Mother",
+                },
+                "gender": 0,
+            },
+            {
+                "_class": "Person",
+                "handle": handle_p4,
+                "primary_name": {
+                    "_class": "Name",
+                    "surname_list": [
+                        {
+                            "_class": "Surname",
+                            "surname": "Doe",
+                        }
+                    ],
+                    "first_name": "Father",
+                },
+                "gender": 1,
+            },
+            {
+                "_class": "Person",
+                "handle": handle_grandf,
+                "primary_name": {
+                    "_class": "Name",
+                    "surname_list": [
+                        {
+                            "_class": "Surname",
+                            "surname": "Doe",
+                        }
+                    ],
+                    "first_name": "Grandfather",
+                },
+                "gender": 1,
+            },
+            {
+                "_class": "Family",
+                "handle": handle_f1,
+                "father_handle": handle_p4,
+                "child_ref_list": [{"_class": "ChildRef", "ref": handle_p1}],
+            },
+            {
+                "_class": "Family",
+                "handle": handle_f2,
+                "mother_handle": handle_p3,
+                "child_ref_list": [{"_class": "ChildRef", "ref": handle_p2}],
+            },
+            {
+                "_class": "Family",
+                "handle": handle_f3,
+                "father_handle": handle_grandf,
+                "child_ref_list": [
+                    {"_class": "ChildRef", "ref": handle_p3},
+                    {"_class": "ChildRef", "ref": handle_p4},
+                ],
+            },
+            {
+                "_class": "Citation",
+                "handle": handle_c,
+                "note_list": [handle_n3],
+            },
+            {
+                "_class": "Note",
+                "handle": handle_n1,
+                "text": {"_class": "StyledText", "string": match1},
+            },
+            {
+                "_class": "Note",
+                "handle": handle_n2,
+                "text": {"_class": "StyledText", "string": match2},
+            },
+            {
+                "_class": "Note",
+                "handle": handle_n3,
+                "text": {"_class": "StyledText", "string": match3},
+            },
+        ]
+        rv = self.client.post("/api/objects/", json=objects, headers=headers)
+        assert rv.status_code == 201
+        rv = self.client.get(
+            f"/api/people/{handle_p1}/dna/matches?locale=fr", headers=headers
+        )
+        assert rv.status_code == 200
+        assert len(rv.json) == 1
+        data = rv.json[0]
+        assert data["handle"] == handle_p2
+        assert data["ancestor_handles"] == [handle_grandf]
+        assert data["relation"] == "le premier cousin"
+        assert len(data["segments"]) == 4
+        # 1,56950055,64247327,10.9,1404
+        # 5,850055,950055,12,1700
+        # """
+        # match2 = """chromosome	start	end	cMs	SNP	Side
+        # 2	56950055	64247327	10.9	1404	M"""
+        # match3 = """chromosome,start,end,cMs
+        # X,56950055,64247327,10.9"""
+        assert data["segments"][0] == {
+            "chromosome": "1",
+            "start": 56950055,
+            "stop": 64247327,
+            "side": "P",
+            "cM": 10.9,
+            "SNPs": 1404,
+            "comment": "",
+        }
+        assert data["segments"][1] == {
+            "chromosome": "5",
+            "start": 850055,
+            "stop": 950055,
+            "side": "P",
+            "cM": 12,
+            "SNPs": 1700,
+            "comment": "",
+        }
+        assert data["segments"][2] == {
+            "chromosome": "2",
+            "start": 56950055,
+            "stop": 64247327,
+            "side": "M",
+            "cM": 10.9,
+            "SNPs": 1404,
+            "comment": "",
+        }
+        assert data["segments"][3] == {
+            "chromosome": "X",
+            "start": 56950055,
+            "stop": 64247327,
+            "side": "P",
+            "cM": 10.9,
+            "SNPs": 0,
+            "comment": "",
+        }


### PR DESCRIPTION
This PR adds a new endpoint `/api/people/<handle>/dna/matches` that returns matching DNA segments between the person and any other person. It is based on notes with CSVs/TSVs as described in the [DNA Segment Map Gramplet Wiki page](https://gramps-project.org/wiki/index.php/Addon:DNASegmentMapGramplet). The code copies heavily from that Gramplet written by @Nick-Hall and @GaryGriffin, which means that the Gramplet and the API endpoint are compatible with each other; data that works with one will work with the other as well.

This is just a `GET` endpoint as data can be added simply using existing endpoints for notes and people.

Example response:

```json
[
    {
        "ancestor_handles": [
            "ce338b9b-73ff-48c5-8981-444819ec132c"
        ],
        "handle": "d7ddbdbf-cfbe-4fc6-b054-2f10faa99b2c",
        "relation": "le premier cousin",
        "segments": [
            {
                "SNPs": 1404,
                "cM": 10.9,
                "chromosome": "1",
                "comment": "",
                "side": "P",
                "start": 56950055,
                "stop": 64247327
            },
            {
                "SNPs": 1700,
                "cM": 12.0,
                "chromosome": "5",
                "comment": "",
                "side": "P",
                "start": 850055,
                "stop": 950055
            },
            {
                "SNPs": 1404,
                "cM": 10.9,
                "chromosome": "2",
                "comment": "",
                "side": "M",
                "start": 56950055,
                "stop": 64247327
            },
            {
                "SNPs": 0,
                "cM": 10.9,
                "chromosome": "X",
                "comment": "",
                "side": "P",
                "start": 56950055,
                "stop": 64247327
            }
        ]
    }
]
```

Unit tests are added and API specs updated.