### PR TITLE
Write DB in filesystem of config

### DIFF
--- a/gramps_webapi/app.py
+++ b/gramps_webapi/app.py
@@ -76,16 +76,27 @@ def deprecated_config_from_env(app):
 
 def create_app(config: Optional[Dict[str, Any]] = None):
     """Flask application factory."""
-    app = Flask(__name__)
+    provided_cfg_path = os.getenv(ENV_CONFIG_FILE)
+    if provided_cfg_path:
+        app = Flask(
+            __name__,
+            # flask_sqlalchemy tries writing to `instance_path` on startup, so use cfg's dir
+            instance_path=os.path.abspath(os.path.join(provided_cfg_path, os.pardir)),
+            # since `instance_path` is set, could also:
+#           instance_relative_config=True,
+        )
+    else:
+        app = Flask(__name__) # infer `instance_path` (probably under `/var` in venv)
 
     app.logger.setLevel(logging.INFO)
 
     # load default config
     app.config.from_object(DefaultConfig)
 
-    # overwrite with user config file
-    if os.getenv(ENV_CONFIG_FILE):
-        app.config.from_envvar(ENV_CONFIG_FILE)
+    # overwrite with user config file -- `silent` allows this to fail,
+    # in case someone wants to use individual env. vars for config,
+    # but also wants to set the env. var to `/exists/fake.cfg` i.e. just to change the dir
+    app.config.from_pyfile(provided_cfg_path, silent=True)
 
     # use unprefixed environment variables if exist - deprecated!
     deprecated_config_from_env(app)


### PR DESCRIPTION
Background: I've set out to package Gramps Web for Nix ([Nixpkgs](https://github.com/NixOS/nixpkgs)), and then as a provision-ready [module/service for NixOS](https://nixos.wiki/wiki/NixOS_modules). While it should be possible to run Docker, the preferred way is to build from source (or to patch binaries, but for Python there's little difference). I managed to get the backend working by applying this small patch.

The problem I ran into was that SQLAlchemy(?) was trying to write into the Nix store—a read-only filesystem—on startup.
<details>
<summary>Full stacktrace</summary>

```
Traceback (most recent call last):
  File "/nix/store/95cxzy2hpizr23343b8bskl4yacf4b3l-python3-3.10.11/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/nix/store/95cxzy2hpizr23343b8bskl4yacf4b3l-python3-3.10.11/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/nix/store/sf1c33yav9nl40a785zxvxs35lapxrb0-python3-3.10.11-env/lib/python3.10/site-packages/gramps_webapi/__main__.py", line 199, in <module>
    cli(
  File "/nix/store/sf1c33yav9nl40a785zxvxs35lapxrb0-python3-3.10.11-env/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/nix/store/sf1c33yav9nl40a785zxvxs35lapxrb0-python3-3.10.11-env/lib/python3.10/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/nix/store/sf1c33yav9nl40a785zxvxs35lapxrb0-python3-3.10.11-env/lib/python3.10/site-packages/click/core.py", line 1654, in invoke
    super().invoke(ctx)
  File "/nix/store/sf1c33yav9nl40a785zxvxs35lapxrb0-python3-3.10.11-env/lib/python3.10/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/nix/store/sf1c33yav9nl40a785zxvxs35lapxrb0-python3-3.10.11-env/lib/python3.10/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/nix/store/sf1c33yav9nl40a785zxvxs35lapxrb0-python3-3.10.11-env/lib/python3.10/site-packages/click/decorators.py", line 26, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/nix/store/sf1c33yav9nl40a785zxvxs35lapxrb0-python3-3.10.11-env/lib/python3.10/site-packages/gramps_webapi/__main__.py", line 54, in cli
    ctx.obj = {"app": create_app()}
  File "/nix/store/sf1c33yav9nl40a785zxvxs35lapxrb0-python3-3.10.11-env/lib/python3.10/site-packages/gramps_webapi/app.py", line 129, in create_app
    user_db.init_app(app)
  File "/nix/store/sf1c33yav9nl40a785zxvxs35lapxrb0-python3-3.10.11-env/lib/python3.10/site-packages/flask_sqlalchemy/extension.py", line 325, in init_app
    self._apply_driver_defaults(options, app)
  File "/nix/store/sf1c33yav9nl40a785zxvxs35lapxrb0-python3-3.10.11-env/lib/python3.10/site-packages/flask_sqlalchemy/extension.py", line 576, in _apply_driver_defaults
    os.makedirs(app.instance_path, exist_ok=True)
  File "/nix/store/95cxzy2hpizr23343b8bskl4yacf4b3l-python3-3.10.11/lib/python3.10/os.py", line 215, in makedirs
    makedirs(head, exist_ok=exist_ok)
  File "/nix/store/95cxzy2hpizr23343b8bskl4yacf4b3l-python3-3.10.11/lib/python3.10/os.py", line 225, in makedirs
    mkdir(name, mode)
OSError: [Errno 30] Read-only file system: '/nix/store/sf1c33yav9nl40a785zxvxs35lapxrb0-python3-3.10.11-env/var'
```
</details>

After finding the docs for `instance_path`, I then guessed my way to this solution. ~~At least, it seems to have solved the problem; I haven't managed to get the frontend working, and the backend is saying it's a development server so I must still be doing something wrong.~~
edit: ~~I've also just noticed it's writing `$PWD/thumbnail_cache`, so now I'm changing to the persistent data dir in the wrapper script... should this set `instance_path` to the working dir instead?~~ Went with that, to match Docker image.

I must say, it is *infuriating* to have to orient yourself in a mixed Python+JS project with almost zero setup documentation (that doesn't boil down to "use Docker lol"), since they happen to be 2 of the most... shall we say *diverse* ecosystems when it comes to project structure styles.
But I did eventually figure out that the backend uses `setuptools` and `pytest` (though after hours of debugging there were still failures left, so I just skipped running tests entirely—doesn't help that they're slow as molasses) and the frontend uses `npm run build`.