### PR TITLE
Add endpoint for text recognition (OCR)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install Ubuntu dependencies
-        run: sudo apt update && sudo apt-get -y install gettext appstream pkg-config libcairo2-dev gir1.2-gtk-3.0 libgirepository1.0-dev libicu-dev libopencv-dev python3-opencv python3-numpy gramps
+        run: sudo apt update && sudo apt-get -y install gettext appstream pkg-config libcairo2-dev gir1.2-gtk-3.0 libgirepository1.0-dev libicu-dev libopencv-dev python3-opencv python3-numpy gramps tesseract-ocr tesseract-ocr-all
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip wheel

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update && apt-get install -y \
   libpq-dev postgresql-client postgresql-client-common python3-psycopg2 \
   libgl1-mesa-dev libgtk2.0-dev libatlas-base-dev \
   libopencv-dev python3-opencv \
+  tesseract-ocr tesseract-ocr-all \
   && rm -rf /var/lib/apt/lists/*
 
 # set locale

--- a/gramps_webapi/api/__init__.py
+++ b/gramps_webapi/api/__init__.py
@@ -32,6 +32,7 @@ from .resources.base import Resource
 from .resources.bookmarks import BookmarkResource, BookmarksResource
 from .resources.citations import CitationResource, CitationsResource
 from .resources.config import ConfigResource, ConfigsResource
+from .resources.dna import PersonDnaMatchesResource
 from .resources.events import EventResource, EventSpanResource, EventsResource
 from .resources.export_media import MediaArchiveFileResource, MediaArchiveResource
 from .resources.exporters import (
@@ -59,8 +60,8 @@ from .resources.name_formats import NameFormatsResource
 from .resources.name_groups import NameGroupsResource
 from .resources.notes import NoteResource, NotesResource
 from .resources.objects import CreateObjectsResource
+from .resources.ocr import MediaOcrResource
 from .resources.people import PeopleResource, PersonResource
-from .resources.dna import PersonDnaMatchesResource
 from .resources.places import PlaceResource, PlacesResource
 from .resources.relations import RelationResource, RelationsResource
 from .resources.reports import (
@@ -335,6 +336,12 @@ register_endpt(
     MediaFaceDetectionResource,
     "/media/<string:handle>/face_detection",
     "media_face_detection",
+)
+# OCR
+register_endpt(
+    MediaOcrResource,
+    "/media/<string:handle>/ocr",
+    "media_ocr",
 )
 
 # Media export

--- a/gramps_webapi/api/file.py
+++ b/gramps_webapi/api/file.py
@@ -116,7 +116,7 @@ class FileHandler:
         fobj = self.get_file_object()
         image = Image.open(fobj)
         if output_format == "string":
-            data = {"string": pytesseract.image_to_string(image, lang=lang)}
+            data = pytesseract.image_to_string(image, lang=lang)
         elif output_format == "boxes":
             data = pytesseract.image_to_boxes(image, lang=lang, output_type="dict")
         elif output_format == "data":

--- a/gramps_webapi/api/resources/ocr.py
+++ b/gramps_webapi/api/resources/ocr.py
@@ -1,0 +1,66 @@
+#
+# Gramps Web API - A RESTful API for the Gramps genealogy program
+#
+# Copyright (C) 2023      David Straub
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+"""Endpoint for text recognition (OCR)."""
+
+from http import HTTPStatus
+from typing import Dict
+
+from flask import Response, abort, jsonify
+from gramps.gen.errors import HandleError
+from webargs import fields, validate
+
+from ...auth.const import PERM_VIEW_PRIVATE
+from ..auth import has_permissions
+from ..tasks import AsyncResult, make_task_response, media_ocr, run_task
+from ..util import get_db_handle, get_tree_from_jwt, use_args
+from . import ProtectedResource
+
+
+class MediaOcrResource(ProtectedResource):
+    """Resource for media files."""
+
+    @use_args(
+        {
+            "lang": fields.Str(required=True, validate=validate.Length(min=1)),
+            "format": fields.Str(load_default="string"),
+        },
+        location="query",
+    )
+    def post(self, args: Dict, handle) -> Response:
+        """Execute OCR on a file."""
+        db_handle = get_db_handle()
+        try:
+            db_handle.get_media_from_handle(handle)
+        except HandleError:
+            abort(HTTPStatus.NOT_FOUND)
+        tree = get_tree_from_jwt()
+        task = run_task(
+            media_ocr,
+            tree=tree,
+            handle=handle,
+            view_private=has_permissions({PERM_VIEW_PRIVATE}),
+            lang=args["lang"],
+            output_format=args["format"],
+        )
+        if isinstance(task, AsyncResult):
+            return make_task_response(task)
+        if isinstance(task, (str, bytes)):
+            return task, 201
+        return jsonify(task), 201

--- a/gramps_webapi/api/tasks.py
+++ b/gramps_webapi/api/tasks.py
@@ -216,3 +216,17 @@ def import_media_archive(tree: str, file_name: str, delete: bool = True):
         delete=delete,
     )
     return result
+
+
+@shared_task()
+def media_ocr(
+    tree: str, handle: str, view_private: bool, lang: str, output_format: str = "string"
+):
+    """Perform text recognition (OCR) on a media object."""
+    db_handle = get_db_outside_request(
+        tree=tree, view_private=view_private, readonly=True
+    )
+    handler = get_media_handler(db_handle, tree).get_file_handler(
+        handle, db_handle=db_handle
+    )
+    return handler.get_ocr(lang=lang, output_format=output_format)

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -3767,6 +3767,57 @@ paths:
         501:
           description: "Not Implemented: Server does not support face detection."
 
+  /media/{handle}/ocr:
+    parameters:
+    - name: handle
+      in: path
+      required: true
+      type: string
+      minLength: 8
+      description: "The unique identifier for a media item."
+    - name: lang
+      in: query
+      required: true
+      type: string
+      description: "A tesseract language identifier."
+      example: "eng"
+    - name: format
+      in: query
+      required: false
+      type: string
+      enum:
+        - string
+        - data
+        - boxes
+        - hocr
+      description: "Requested output format. Defaults to 'string'."
+    post:
+      tags:
+      - media
+      summary: "Perform text recognition (OCR) on the image."
+      operationId: postMediaItemOCR
+      security:
+        - Bearer: []
+      responses:
+        201:
+          description: "OK: Successful operation."
+        202:
+          description: "Accepted: text recognition will be peerformed in the background."
+          schema:
+            type: object
+            properties:
+              task:
+                $ref: "#/definitions/TaskReference"
+        401:
+          description: "Unauthorized: Missing authorization header."
+        404:
+          description: "Not Found: Media item not found."
+        422:
+          description: "Unprocessable Entity: Invalid or bad parameter provided."
+        501:
+          description: "Not Implemented: Server does not support text recognition."
+
+
   /media/{handle}/thumbnail/{size}:
     get:
       tags:
@@ -9518,6 +9569,19 @@ definitions:
             description: "Indicates whether the server is using a task queue for long running operations."
             type: boolean
             example: false
+          has_ocr:
+            description: "Indicates whether the server supports text recognition (OCR)."
+            type: boolean
+            example: false
+          ocr_languages:
+            description: "List of supported OCR languages (tesseract language codes)."
+            type: array
+            items:
+              type: string
+            example:
+              - eng
+              - deu
+
       surnames:
         description: "A list of all surnames found in the database."
         type: array

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ REQUIREMENTS = [
     "alembic",
     "celery[redis]",
     "Unidecode",
+    "pytesseract",
 ]
 
 setup(

--- a/tests/test_endpoints/test_ocr.py
+++ b/tests/test_endpoints/test_ocr.py
@@ -124,6 +124,7 @@ class TestOcr(unittest.TestCase):
             f"{TEST_URL}{handle}/ocr?lang=eng&format=boxes", headers=headers
         )
         assert rv.status_code == 201
+        data = rv.json
         assert "char" in data
         assert "O" in data["char"]
         assert "C" in data["char"]

--- a/tests/test_endpoints/test_ocr.py
+++ b/tests/test_endpoints/test_ocr.py
@@ -1,0 +1,137 @@
+#
+# Gramps Web API - A RESTful API for the Gramps genealogy program
+#
+# Copyright (C) 2023      David Straub
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+"""Tests for the OCR endpoint."""
+
+import os
+import shutil
+import tempfile
+import unittest
+from io import BytesIO
+from unittest.mock import patch
+
+from gramps.cli.clidbman import CLIDbManager
+from gramps.gen.dbstate import DbState
+from PIL import Image, ImageDraw, ImageFont
+
+from gramps_webapi.app import create_app
+from gramps_webapi.auth import add_user, user_db
+from gramps_webapi.auth.const import ROLE_GUEST, ROLE_OWNER
+from gramps_webapi.const import ENV_CONFIG_FILE, TEST_AUTH_CONFIG
+
+from . import BASE_URL
+
+TEST_URL = BASE_URL + "/media/"
+
+
+class TestOcr(unittest.TestCase):
+    """Test text recognition (OCR)."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.name = "Test Web API"
+        cls.dbman = CLIDbManager(DbState())
+        dirpath, _ = cls.dbman.create_new_db_cli(cls.name, dbid="sqlite")
+        tree = os.path.basename(dirpath)
+        with patch.dict("os.environ", {ENV_CONFIG_FILE: TEST_AUTH_CONFIG}):
+            cls.app = create_app()
+        cls.app.config["TESTING"] = True
+        cls.media_base_dir = tempfile.mkdtemp()
+        cls.app.config["MEDIA_BASE_DIR"] = cls.media_base_dir
+        cls.client = cls.app.test_client()
+        with cls.app.app_context():
+            user_db.create_all()
+            add_user(name="user", password="123", role=ROLE_GUEST, tree=tree)
+            add_user(name="owner", password="123", role=ROLE_OWNER, tree=tree)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.dbman.remove_database(cls.name)
+        shutil.rmtree(cls.media_base_dir)
+
+    def test_get_ocr(self):
+        """Test OCR."""
+        # get token
+        rv = self.client.post(
+            "/api/token/", json={"username": "owner", "password": "123"}
+        )
+        access_token = rv.json["access_token"]
+        headers = {"Authorization": f"Bearer {access_token}"}
+
+        # create image
+        image = Image.new("RGB", (300, 100), "white")
+        draw = ImageDraw.Draw(image)
+        try:
+            font = ImageFont.truetype("Helvetica.ttf", 18)
+        except OSError:
+            font = ImageFont.truetype("Arial.ttf", 18)
+        except OSError:
+            font = ImageFont.truetype("DejaVuSans", 18)
+        draw.text((10, 10), "OCR Demo", font=font, fill="black")
+
+        # post image
+        image_bytes_io = BytesIO()
+        image.save(image_bytes_io, format="PNG")
+        image_bytes = image_bytes_io.getvalue()
+        rv = self.client.post(
+            TEST_URL, headers=headers, data=image_bytes, content_type="image/jpeg"
+        )
+        assert rv.status_code == 201
+        assert len(rv.json) == 1
+        handle = rv.json[0]["handle"]
+
+        # run OCR - not found
+        rv = self.client.post(f"{TEST_URL}idontexist/ocr?lang=eng", headers=headers)
+        assert rv.status_code == 404
+
+        # run OCR - missing lang
+        rv = self.client.post(f"{TEST_URL}idontexist/ocr", headers=headers)
+        assert rv.status_code == 422
+
+        # run OCR - string
+        rv = self.client.post(f"{TEST_URL}{handle}/ocr?lang=eng", headers=headers)
+        assert rv.status_code == 201
+        data = rv.text
+        assert "OCR Demo" in data
+
+        # run OCR - data
+        rv = self.client.post(
+            f"{TEST_URL}{handle}/ocr?lang=eng&format=data", headers=headers
+        )
+        assert rv.status_code == 201
+        data = rv.json
+        assert "text" in data
+        assert "OCR" in data["text"]
+
+        # run OCR - boxes
+        rv = self.client.post(
+            f"{TEST_URL}{handle}/ocr?lang=eng&format=boxes", headers=headers
+        )
+        assert rv.status_code == 201
+        assert "char" in data
+        assert "O" in data["char"]
+        assert "C" in data["char"]
+        assert "R" in data["char"]
+
+        # run OCR - hocr
+        rv = self.client.post(
+            f"{TEST_URL}{handle}/ocr?lang=eng&format=hocr", headers=headers
+        )
+        assert rv.status_code == 201
+        assert "<?xml" in rv.text

--- a/tests/test_endpoints/test_ocr.py
+++ b/tests/test_endpoints/test_ocr.py
@@ -77,12 +77,12 @@ class TestOcr(unittest.TestCase):
         # create image
         image = Image.new("RGB", (300, 100), "white")
         draw = ImageDraw.Draw(image)
-        try:
-            font = ImageFont.truetype("Helvetica.ttf", 18)
-        except OSError:
-            font = ImageFont.truetype("Arial.ttf", 18)
-        except OSError:
-            font = ImageFont.truetype("DejaVuSans", 18)
+        for font_name in ["Helvetica.ttf", "Arial.ttf", "DejaVuSans"]:
+            try:
+                font = ImageFont.truetype(font_name, 18)
+                break
+            except OSError:
+                pass
         draw.text((10, 10), "OCR Demo", font=font, fill="black")
 
         # post image


### PR DESCRIPTION
Fixes #445, uses `pytesseract`.

New endpoint: `POST` to `/media/<handle>/ocr`

Query parameters:

- `lang` (required) - a tesseract language code (e.g. `eng`)
- `format`: the output format (default is `string`)

It's `POST` because the task queue is used when available. Although OCR should be pretty fast, this seems more robust and might allow OCR'ing multi-page PDFs in the future (currently, only images are supported).