### PR TITLE
Make reports load much faster

### DIFF
--- a/gramps_webapi/api/resources/reports.py
+++ b/gramps_webapi/api/resources/reports.py
@@ -34,12 +34,7 @@ from ...const import MIME_TYPES
 from ..auth import has_permissions
 from ..report import check_report_id_exists, get_reports, run_report
 from ..tasks import AsyncResult, generate_report, make_task_response, run_task
-from ..util import (
-    get_buffer_for_file,
-    get_db_handle,
-    get_tree_from_jwt,
-    use_args,
-)
+from ..util import get_buffer_for_file, get_db_handle, get_tree_from_jwt, use_args
 from . import ProtectedResource
 from .emit import GrampsJSONEncoder
 from .util import check_fix_default_person
@@ -48,24 +43,30 @@ from .util import check_fix_default_person
 class ReportsResource(ProtectedResource, GrampsJSONEncoder):
     """Reports resource."""
 
-    @use_args({}, location="query")
+    @use_args({"include_help": fields.Boolean(load_default=False)}, location="query")
     def get(self, args: Dict) -> Response:
         """Get all available report attributes."""
         if has_permissions({PERM_EDIT_OBJ}):
             check_fix_default_person(get_db_handle(readonly=False))
-        reports = get_reports(get_db_handle())
+        reports = get_reports(
+            get_db_handle(), include_options_help=args["include_help"]
+        )
         return self.response(200, reports)
 
 
 class ReportResource(ProtectedResource, GrampsJSONEncoder):
     """Report resource."""
 
-    @use_args({}, location="query")
+    @use_args({"include_help": fields.Boolean(load_default=True)}, location="query")
     def get(self, args: Dict, report_id: str) -> Response:
         """Get specific report attributes."""
         if has_permissions({PERM_EDIT_OBJ}):
             check_fix_default_person(get_db_handle(readonly=False))
-        reports = get_reports(get_db_handle(), report_id=report_id)
+        reports = get_reports(
+            get_db_handle(),
+            report_id=report_id,
+            include_options_help=args["include_help"],
+        )
         if not reports:
             abort(404)
         return self.response(200, reports[0])

--- a/gramps_webapi/data/apispec.yaml
+++ b/gramps_webapi/data/apispec.yaml
@@ -5924,6 +5924,13 @@ paths:
       operationId: getAllReports
       security:
         - Bearer: []
+      parameters:
+      - name: include_help
+        in: query
+        required: false
+        type: boolean
+        default: false
+        description: "Indicates whether the report options help should be included."
       responses:
         200:
           description: "OK: Successful operation."
@@ -5951,6 +5958,12 @@ paths:
         required: true
         type: string
         description: "The report identifier."
+      - name: include_help
+        in: query
+        required: false
+        type: boolean
+        default: true
+        description: "Indicates whether the report options help should be included."
       responses:
         200:
           description: "OK: Successful operation."

--- a/tests/test_endpoints/test_reports.py
+++ b/tests/test_endpoints/test_reports.py
@@ -58,6 +58,14 @@ class TestReports(unittest.TestCase):
         """Test invalid parameters and values."""
         check_invalid_semantics(self, TEST_URL + "?test=1")
 
+    def test_get_reports_validate_semantics_without_help(self):
+        """Test invalid parameters and values."""
+        check_invalid_semantics(self, TEST_URL + "?include_help")
+
+    def test_get_reports_without_help(self):
+        """Test invalid parameters and values."""
+        check_success(self, TEST_URL + "?include_help=0")
+
 
 class TestReportsReportId(unittest.TestCase):
     """Test cases for the /api/reports/{report_id} endpoint."""
@@ -82,6 +90,14 @@ class TestReportsReportId(unittest.TestCase):
     def test_get_reports_report_id_validate_semantics(self):
         """Test invalid parameters and values."""
         check_invalid_semantics(self, TEST_URL + "ancestor_report?test=1")
+
+    def test_get_report_id_validate_semantics_without_help(self):
+        """Test invalid parameters and values."""
+        check_invalid_semantics(self, TEST_URL + "ancestor_report?include_help")
+
+    def test_get_report_id_without_help(self):
+        """Test invalid parameters and values."""
+        check_success(self, TEST_URL + "ancestor_report?include_help=0")
 
 
 class TestReportsReportIdFile(unittest.TestCase):


### PR DESCRIPTION
This fixes #451 but was quite painful. I needed to subclass `CommandLineReport` to remove very costly individual DB calls to every object in the database for multiple reports. This was made harder by Gramps using name mangling in the parent class :roll_eyes: 

Even with this patched, it was still kind of slow and I realized that for Gramps Web, there is no point in even building the options help for all reports when just showing the list. So I added a new API parameter `include_help` which defaults to `false` for `/reports/` and `true` for `/reports/<id>`. This might seem strange and is strictly speaking not backwards compatible for the API, but it allows a backwards compatible change for Gramps Web, since the frontend doesn't need to be changed.