### PR TITLE
Optionally ignore lock file

### DIFF
--- a/gramps_webapi/__main__.py
+++ b/gramps_webapi/__main__.py
@@ -28,12 +28,11 @@ import warnings
 import click
 from whoosh.index import LockError
 
-
 from .api.util import get_db_manager, get_search_indexer, list_trees
-from .dbmanager import WebDbManager
 from .app import create_app
 from .auth import add_user, delete_user, fill_tree, user_db
 from .const import ENV_CONFIG_FILE, TREE_MULTI
+from .dbmanager import WebDbManager
 
 logging.basicConfig()
 LOG = logging.getLogger("gramps_webapi")
@@ -128,7 +127,11 @@ def search(ctx, tree):
         if app.config["TREE"] == TREE_MULTI:
             raise ValueError("`tree` is required when multi-tree support is enabled.")
         # needed for backwards compatibility!
-        dbmgr = WebDbManager(name=app.config["TREE"], create_if_missing=False)
+        dbmgr = WebDbManager(
+            name=app.config["TREE"],
+            create_if_missing=False,
+            ignore_lock=app.config["IGNORE_DB_LOCK"],
+        )
         tree = dbmgr.dirname
     with app.app_context():
         ctx.obj["db_manager"] = get_db_manager(tree=tree)

--- a/gramps_webapi/api/resources/trees.py
+++ b/gramps_webapi/api/resources/trees.py
@@ -50,7 +50,11 @@ TREE_ID_REGEX = re.compile(r"^[a-zA-Z0-9_-]+$")
 def get_tree_details(tree_id: str) -> Dict[str, str]:
     """Get details about a tree."""
     try:
-        dbmgr = WebDbManager(dirname=tree_id, create_if_missing=False)
+        dbmgr = WebDbManager(
+            dirname=tree_id,
+            create_if_missing=False,
+            ignore_lock=current_app.config["IGNORE_DB_LOCK"],
+        )
     except ValueError:
         abort(404)
     usage = get_tree_usage(tree_id) or {}
@@ -100,7 +104,7 @@ class TreesResource(ProtectedResource):
         require_permissions([PERM_ADD_TREE])
         tree_id = str(uuid.uuid4())
         backend = current_app.config["NEW_DB_BACKEND"]
-        dbmgr = WebDbManager(
+        WebDbManager(
             dirname=tree_id,
             name=args["name"],
             create_if_missing=True,
@@ -153,7 +157,11 @@ class TreeResource(ProtectedResource):
                 require_permissions([PERM_EDIT_OTHER_TREE])
                 validate_tree_id(tree_id)
         try:
-            dbmgr = WebDbManager(dirname=tree_id, create_if_missing=False)
+            dbmgr = WebDbManager(
+                dirname=tree_id,
+                create_if_missing=False,
+                ignore_lock=current_app.config["IGNORE_DB_LOCK"],
+            )
         except ValueError:
             abort(404)
         rv = {}

--- a/gramps_webapi/api/util.py
+++ b/gramps_webapi/api/util.py
@@ -37,17 +37,17 @@ from gramps.gen.config import config
 from gramps.gen.const import GRAMPS_LOCALE
 from gramps.gen.db.base import DbReadBase
 from gramps.gen.db.dbconst import (
+    CITATION_KEY,
     DBBACKEND,
-    KEY_TO_NAME_MAP,
-    PERSON_KEY,
-    FAMILY_KEY,
-    SOURCE_KEY,
     EVENT_KEY,
+    FAMILY_KEY,
+    KEY_TO_NAME_MAP,
     MEDIA_KEY,
+    NOTE_KEY,
+    PERSON_KEY,
     PLACE_KEY,
     REPOSITORY_KEY,
-    NOTE_KEY,
-    CITATION_KEY,
+    SOURCE_KEY,
 )
 from gramps.gen.dbstate import DbState
 from gramps.gen.errors import HandleError
@@ -254,6 +254,7 @@ def get_db_manager(tree: Optional[str]) -> WebDbManager:
         username=current_app.config["POSTGRES_USER"],
         password=current_app.config["POSTGRES_PASSWORD"],
         create_if_missing=False,
+        ignore_lock=current_app.config["IGNORE_DB_LOCK"],
     )
 
 
@@ -472,7 +473,11 @@ def get_tree_id(guid: str) -> str:
             # multi-tree support enabled but user has no tree ID: forbidden!
             abort_with_message(403, "Forbidden")
         # needed for backwards compatibility: single-tree mode but user without tree ID
-        dbmgr = WebDbManager(name=current_app.config["TREE"], create_if_missing=False)
+        dbmgr = WebDbManager(
+            name=current_app.config["TREE"],
+            create_if_missing=False,
+            ignore_lock=current_app.config["IGNORE_DB_LOCK"],
+        )
         tree_id = dbmgr.dirname
     return tree_id
 

--- a/gramps_webapi/app.py
+++ b/gramps_webapi/app.py
@@ -105,7 +105,11 @@ def create_app(config: Optional[Dict[str, Any]] = None):
 
     if app.config["TREE"] != TREE_MULTI:
         # create database if missing (only in single-tree mode)
-        WebDbManager(name=app.config["TREE"], create_if_missing=True)
+        WebDbManager(
+            name=app.config["TREE"],
+            create_if_missing=True,
+            ignore_lock=app.config["IGNORE_DB_LOCK"],
+        )
 
     if app.config["TREE"] == TREE_MULTI and not app.config["MEDIA_PREFIX_TREE"]:
         warnings.warn(

--- a/gramps_webapi/config.py
+++ b/gramps_webapi/config.py
@@ -48,6 +48,7 @@ class DefaultConfig(object):
     POSTGRES_PASSWORD = None
     POSTGRES_HOST = "localhost"
     POSTGRES_PORT = "5432"
+    IGNORE_DB_LOCK = False
     CELERY_CONFIG: Dict[str, str] = {}
     MEDIA_BASE_DIR = ""
     MEDIA_PREFIX_TREE = False

--- a/gramps_webapi/dbloader.py
+++ b/gramps_webapi/dbloader.py
@@ -36,7 +36,6 @@ from gramps.gen.plug import BasePluginManager
 from gramps.gen.recentfiles import recent_files
 from gramps.gen.utils.config import get_researcher
 
-
 _ = glocale.translation.gettext
 
 LOG = logging.getLogger(__name__)
@@ -106,9 +105,17 @@ class WebDbSessionManager:
         # set readonly correctly again
         self.dbstate.db.readonly = mode == DBMODE_R
 
-    def open_activate(self, filename, mode, username=None, password=None):
+    def open_activate(
+        self,
+        filename,
+        mode,
+        username=None,
+        password=None,
+        ignore_lock: bool = False,
+    ):
         """Open and make a family tree active."""
-        check_lock(dir_name=filename, mode=mode)
+        if not ignore_lock:
+            check_lock(dir_name=filename, mode=mode)
         self.read_file(filename, mode, username, password)
         # Attempt to figure out the database title
         title = get_title(filename)


### PR DESCRIPTION
Gramps uses a lock file to ensure only one instance accesses a database at a time. So far, Web API respects this lock file, which makes sense e.g. when accessing the same database simultaneously with Web API and desktop. However, on a separate web server with multi-user access, this does not make sense as it can lead to errors when two requests happen simultaneously. Note that not respecting the lock file does not lead to inconsistencies - all database operations are still wrapped in transactions.

To preserve backwards compatibility, this PR adds the _option_ to ignore the lock file through a configuration parameter, the default being the existing behaviour. The recommended setting will be to enable this on a web server where a desktop instance will not be used to access the database.