### PR TITLE
Fix issue with get_file_size and S3

### DIFF
--- a/gramps_webapi/api/s3.py
+++ b/gramps_webapi/api/s3.py
@@ -121,8 +121,9 @@ class ObjectStorageFileHandler(FileHandler):
 
     def get_file_size(self) -> int:
         """Return the file size in bytes."""
-        self.client.head_object(Bucket=self.bucket_name, Key=self.object_name)
-        response = self.client.head_object(Bucket=self.bucket_name, Key=key)
+        response = self.client.head_object(
+            Bucket=self.bucket_name, Key=self.object_name
+        )
         file_size = response["ContentLength"]
         return file_size
 


### PR DESCRIPTION
This fixes a bug with getting the file size when using object storage for media files.